### PR TITLE
More gracefully handle missing claim and missing fullUrl

### DIFF
--- a/lib/davinci_pas_test_kit/custom_groups/v2.0.1/client_tests/pas_client_approval_submit_response_attest.rb
+++ b/lib/davinci_pas_test_kit/custom_groups/v2.0.1/client_tests/pas_client_approval_submit_response_attest.rb
@@ -20,6 +20,7 @@ module DaVinciPASTestKit
             )
 
       run do
+        skip_if request.status.between?(400, 499), 'Bad claim submission request.'
         wait(
           identifier: access_token,
           message: %(

--- a/lib/davinci_pas_test_kit/pas_bundle_validation.rb
+++ b/lib/davinci_pas_test_kit/pas_bundle_validation.rb
@@ -465,7 +465,7 @@ module DaVinciPASTestKit
       url_regex = /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
       urn_uuid_regex = /\Aurn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\z/i
 
-      string.match?(url_regex) || string.match?(urn_uuid_regex)
+      string&.match?(url_regex) || string&.match?(urn_uuid_regex)
     end
 
     # This method traverses references within a FHIR resource, ensuring that referenced resources


### PR DESCRIPTION
# Summary

Issue: In the client suite, we were return a 500 "low level error occurred" in the event that a claim submission was missing a claim or if the claim was missing a fullUrl (which are both required in the spec). The claim validation test also resulted in an inferno error if there was no fullUrl.

Resolution: Add a check to avoid a 500, return a 400 with an appropriate OperationOutcome instead. Also add safe navigation in the validation module to avoid an inferno error in the validation test.

# Testing Guidance

Run a $submit test. Send it a bundle without a claim. Sent it a bundle with a claim that is missing a fullUrl.
