### PR TITLE
documentation pointers to known validator errors due to spec issues

### DIFF
--- a/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md
+++ b/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md
@@ -174,5 +174,6 @@ These and any other requirements found in the PAS IG may be tested in future ver
 ### Known Issues
 
 Testing has identified issues with the source IG that result in spurious failures. 
-Tests impacted by these issues have an indication in their documentations. You can find the full 
-list of known issues [here](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).
+Tests impacted by these issues have an indication in their documentations. The full
+list of known issues can be found on the [repository's issues page with the 'source ig issue'
+lable](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).

--- a/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md
+++ b/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md
@@ -170,3 +170,9 @@ The PAS IG places additional requirements on clients that are not currently test
 details of the prior authorization request before submitting them
 
 These and any other requirements found in the PAS IG may be tested in future versions of these tests.
+
+### Known Issues
+
+Testing has identified issues with the source IG that result in spurious failures. 
+Tests impacted by these issues have an indication in their documentations. You can find the full 
+list of known issues [here](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).

--- a/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md
+++ b/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md
@@ -148,3 +148,9 @@ The PAS IG places additional requirements on servers that are not currently test
 - Collection of metrics
 
 These and any other requirements found in the PAS IG may be tested in future versions of these tests.
+
+### Known Issues
+
+Testing has identified issues with the source IG that result in spurious failures. 
+Tests impacted by these issues have an indication in their documentations. You can find the full 
+list of known issues [here](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).

--- a/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md
+++ b/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md
@@ -152,5 +152,6 @@ These and any other requirements found in the PAS IG may be tested in future ver
 ### Known Issues
 
 Testing has identified issues with the source IG that result in spurious failures. 
-Tests impacted by these issues have an indication in their documentations. You can find the full 
-list of known issues [here](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).
+Tests impacted by these issues have an indication in their documentations. The full
+list of known issues can be found on the [repository's issues page with the 'source ig issue'
+lable](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb
@@ -29,6 +29,13 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+
+        **Limitations**
+
+        Due to recognized errors in the DTR IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See more details
+        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
       )
 
       def resource_type

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb
@@ -34,8 +34,9 @@ module DaVinciPASTestKit
 
         Due to recognized errors in the DTR IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
-        [extension url] is not allowed at this point". See more details
-        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
 
       def resource_type

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb
@@ -29,6 +29,13 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+
+        **Limitations**
+
+        Due to recognized errors in the DTR IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See more details
+        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
       )
 
       def resource_type

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb
@@ -34,8 +34,9 @@ module DaVinciPASTestKit
 
         Due to recognized errors in the DTR IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
-        [extension url] is not allowed at this point". See more details
-        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
 
       def resource_type

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb
@@ -25,6 +25,13 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+
+        **Limitations**
+
+        Due to recognized errors in the DTR IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See more details
+        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
       )
       
       output :dar_code_found, :dar_extension_found

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb
@@ -30,8 +30,9 @@ module DaVinciPASTestKit
 
         Due to recognized errors in the DTR IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
-        [extension url] is not allowed at this point". See more details
-        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
       
       output :dar_code_found, :dar_extension_found

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb
@@ -25,6 +25,13 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+
+        **Limitations**
+
+        Due to recognized errors in the DTR IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See more details
+        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
       )
       
       output :dar_code_found, :dar_extension_found

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb
@@ -30,8 +30,9 @@ module DaVinciPASTestKit
 
         Due to recognized errors in the DTR IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
-        [extension url] is not allowed at this point". See more details
-        [here](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
       
       output :dar_code_found, :dar_extension_found


### PR DESCRIPTION
# Summary

Address known extension context issues that cause spurious validation errors through documentation (issue: https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)

# Testing Guidance

1. Review all PAS Client and Server tests and check that in any tests involving validation of a response bundle (submit or inquiry), the documentation ("about" tab) includes a "limitations" section that links back to [this issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11).
2. Review the suite documentation to verify that there is a "known issues" section there as well pointing to a list of issues tagged with the "source ig issue" label (https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue) - this list currently includes one issue.
