### PR TITLE
create unique identifier for pended test wait continuation

### DIFF
--- a/lib/davinci_pas_test_kit/custom_groups/v2.0.1/notification/pas_subscription_notification_test.rb
+++ b/lib/davinci_pas_test_kit/custom_groups/v2.0.1/notification/pas_subscription_notification_test.rb
@@ -15,17 +15,17 @@ module DaVinciPASTestKit
       )
 
       run do
-        identifier = SecureRandom.hex(32)
+        token = SecureRandom.hex(32)
         # rubocop:disable Layout/LineLength
         wait(
-          identifier:,
+          identifier: token,
           message: %(
             Inferno has received a 'Pended' claim response indicating that a final decision
             has not yet been made on the prior authorization request.
 
             Please
             **[click
-            here](#{Inferno::Application['base_url']}/custom/davinci_pas_server_suite_v201/resume_after_notification?token=#{identifier})**
+            here](#{Inferno::Application['base_url']}/custom/davinci_pas_server_suite_v201/resume_after_notification?token=#{token})**
             when the status of this claim has been finalized to inform Inferno to resume testing.
 
             Future versions of this test will validate subscription-based notifications as

--- a/lib/davinci_pas_test_kit/custom_groups/v2.0.1/notification/pas_subscription_notification_test.rb
+++ b/lib/davinci_pas_test_kit/custom_groups/v2.0.1/notification/pas_subscription_notification_test.rb
@@ -15,16 +15,17 @@ module DaVinciPASTestKit
       )
 
       run do
+        identifier = SecureRandom.hex(32)
         # rubocop:disable Layout/LineLength
         wait(
-          identifier: 'pended',
+          identifier:,
           message: %(
             Inferno has received a 'Pended' claim response indicating that a final decision
             has not yet been made on the prior authorization request.
 
             Please
             **[click
-            here](#{Inferno::Application['base_url']}/custom/davinci_pas_server_suite_v201/resume_after_notification?use_case=pended)**
+            here](#{Inferno::Application['base_url']}/custom/davinci_pas_server_suite_v201/resume_after_notification?token=#{identifier})**
             when the status of this claim has been finalized to inform Inferno to resume testing.
 
             Future versions of this test will validate subscription-based notifications as

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/server_suite.rb
@@ -30,7 +30,7 @@ module DaVinciPASTestKit
       ]
 
       resume_test_route :get, '/resume_after_notification' do |request|
-        request.query_parameters['use_case']
+        request.query_parameters['token']
       end
 
       fhir_resource_validator do

--- a/lib/davinci_pas_test_kit/generator/templates/suite.rb.erb
+++ b/lib/davinci_pas_test_kit/generator/templates/suite.rb.erb
@@ -27,7 +27,7 @@ module DaVinciPASTestKit
       ]
 
       resume_test_route :get, '/resume_after_notification' do |request|
-        request.query_parameters['use_case']
+        request.query_parameters['token']
       end
 
       fhir_resource_validator do


### PR DESCRIPTION
# Summary

Resolves [issue 13](https://github.com/inferno-framework/davinci-pas-test-kit/issues/13) where the wait dialog for the temporary subscription placeholder was not session specific, meaning that concurrent sessions could interrupt each other. The wait dialog now generates a unique key that is used which will be unique to the session.

# Testing Guidance

Create a PAS Server suite session and run group 1.3 Successful Pended Workflow using the Prior Authorization Support Reference Implementation preset. Verify that when the wait dialog appears, 
1. hovering over the "click here" link shows a url with a random "token" parameter at the end 
2. clicking on the "click here" link successfully continues the test.