### PR TITLE
FI-3279: PAS Fix Limitation Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ particularly the instructions on
 
 ### Test Generation
 
-The Davinci PAS Test Kit has an implemeneted test generator that create some of the
+The Davinci PAS Test Kit has an implemented test generator that create some of the
 tests in this kit from the capability statement and profiles in the IG. It
-extracts necessarry data elements from Davinci Prior Authorization Support Implementation Guide archive files and generates tests accordingly. The repo currently contains
+extracts necessary data elements from Davinci Prior Authorization Support Implementation Guide archive files and generates tests accordingly. The repo currently contains
 suites for IG versions 2.0.1.
 
 To generate a test suite for a different Davinci PAS IG version:

--- a/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md
+++ b/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md
@@ -176,4 +176,4 @@ These and any other requirements found in the PAS IG may be tested in future ver
 Testing has identified issues with the source IG that result in spurious failures. 
 Tests impacted by these issues have an indication in their documentations. The full
 list of known issues can be found on the [repository's issues page with the 'source ig issue'
-lable](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).
+label](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).

--- a/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md
+++ b/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md
@@ -154,4 +154,4 @@ These and any other requirements found in the PAS IG may be tested in future ver
 Testing has identified issues with the source IG that result in spurious failures. 
 Tests impacted by these issues have an indication in their documentations. The full
 list of known issues can be found on the [repository's issues page with the 'source ig issue'
-lable](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).
+label](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb
@@ -29,10 +29,10 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
-
+        
         **Limitations**
-
-        Due to recognized errors in the DTR IG around extension context definitions,
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
         [extension url] is not allowed at this point". See [this
         issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pas_request_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pas_request_bundle_validation_test.rb
@@ -26,6 +26,14 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+        
+        **Limitations**
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
 
       def resource_type

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_inquiry_request_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_inquiry_request_bundle_validation_test.rb
@@ -26,6 +26,14 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+        
+        **Limitations**
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
 
       def resource_type

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb
@@ -29,10 +29,10 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
-
+        
         **Limitations**
-
-        Due to recognized errors in the DTR IG around extension context definitions,
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
         [extension url] is not allowed at this point". See [this
         issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_request_bundle/server_pas_inquiry_request_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_request_bundle/server_pas_inquiry_request_bundle_validation_test.rb
@@ -28,6 +28,14 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+        
+        **Limitations**
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
       
       input :pa_inquire_request_payload,

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb
@@ -25,10 +25,10 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
-
+        
         **Limitations**
-
-        Due to recognized errors in the DTR IG around extension context definitions,
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
         [extension url] is not allowed at this point". See [this
         issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_request_bundle/server_pas_request_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_request_bundle/server_pas_request_bundle_validation_test.rb
@@ -28,6 +28,14 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
+        
+        **Limitations**
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
+        this test may not pass due to spurious errors of the form "The extension
+        [extension url] is not allowed at this point". See [this
+        issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+        for additional details.
       )
       
       input :pa_submit_request_payload,

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb
@@ -25,10 +25,10 @@ module DaVinciPASTestKit
         
         Note that because X12 value sets are not public, elements bound to value
         sets containing X12 codes are not validated.
-
+        
         **Limitations**
-
-        Due to recognized errors in the DTR IG around extension context definitions,
+        
+        Due to recognized errors in the PAS IG around extension context definitions,
         this test may not pass due to spurious errors of the form "The extension
         [extension url] is not allowed at this point". See [this
         issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)

--- a/lib/davinci_pas_test_kit/generator/validation_test_generator.rb
+++ b/lib/davinci_pas_test_kit/generator/validation_test_generator.rb
@@ -151,6 +151,14 @@ module DaVinciPASTestKit
 
           Note that because X12 value sets are not public, elements bound to value
           sets containing X12 codes are not validated.
+
+          **Limitations**
+  
+          Due to recognized errors in the PAS IG around extension context definitions,
+          this test may not pass due to spurious errors of the form "The extension
+          [extension url] is not allowed at this point". See [this
+          issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues/11)
+          for additional details.
         DESCRIPTION
       end
 

--- a/lib/davinci_pas_test_kit/generator/validation_test_generator.rb
+++ b/lib/davinci_pas_test_kit/generator/validation_test_generator.rb
@@ -153,7 +153,7 @@ module DaVinciPASTestKit
           sets containing X12 codes are not validated.
 
           **Limitations**
-  
+
           Due to recognized errors in the PAS IG around extension context definitions,
           this test may not pass due to spurious errors of the form "The extension
           [extension url] is not allowed at this point". See [this


### PR DESCRIPTION
# Description

This ticket updated the validation genetor in order to add the limitation to all validation tests without the need to do so manually. Also fixed the limitation text updating from DTR to PAS

## Important Changes

`lib/davinci_pas_test_kit/generator/validation_test_generator.rb`
- Added limitation documentation to the generator

Added updated validation tests with limitation documentation for the following files
- `lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_denial_pas_response_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pas_request_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_inquiry_request_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/client_tests/client_pended_pas_response_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_request_bundle/server_pas_inquiry_request_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/pas_inquiry_response_bundle/server_pas_inquiry_response_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/pas_request_bundle/server_pas_request_bundle_validation_test.rb`
- `lib/davinci_pas_test_kit/generated/v2.0.1/pas_response_bundle/server_pas_response_bundle_validation_test.rb`

Fixed typos for the following files
- `README.md`
- `lib/davinci_pas_test_kit/docs/client_suite_description_v201.md`
- `lib/davinci_pas_test_kit/docs/server_suite_description_v201.md`

## Testing Recommendations

Make sure all unit tests pass and the application runs as expected. Run both the Client and Server suite and ensure that the limitation statement _"Due to recognized errors in the PAS IG around extension context definitions, this test may not pass due to spurious errors of the form "The extension [extension url] is not allowed at this point". See [this issue] for additional details."_ appears for the following tests in their about sections.

PAS Client
- 2.1.1 Demonstrate Approval Workflow
  - 2.1.1.02 Request Bundle is valid

- 2.1.2 Demonstrate Denial Workflow
  - 2.1.2.02 [USER INPUT VALIDATION] Response Bundle is valid
  - 2.1.2.03 Request Bundle is valid
 
- 2.1.3 Demonstrate Pended Workflow
  - 2.1.3.02 [USER INPUT VALIDATION] Response Bundle is valid
  - 2.1.3.03 Request Bundle is valid
  - 2.1.3.06 Inquiry Request Bundle is valid

PAS Server
- 1.1 Successful Approval Workflow
  - 1.1.1.01 [USER INPUT VALIDATION] Request Bundle is valid
  - 1.1.1.03 Response Bundle is valid

- 1.2 Successful Denial Workflow
  - 1.2.1.01 [USER INPUT VALIDATION] Request Bundle is valid
  - 1.2.1.03 Response Bundle is valid
 
- 1.3 Successful Pended Workflow
  - 1.3.1.01 [USER INPUT VALIDATION] Request Bundle is valid
  - 1.3.1.03 Response Bundle is valid
  - 1.3.2.02 [USER INPUT VALIDATION] Inquiry Request Bundle is valid
  - 1.3.2.04 Inquiry Response Bundle is valid
 
- 2.2 $inquire Element Support
  - 2.2.1.01 [USER INPUT VALIDATION] Inquiry Request Bundle is valid
  - 2.2.1.03 Inquiry Response Bundle is valid

Additionally ensure generator runs as expected `bundle exec rake pas:generate`

# Checklists

**Submitter:**
- [x] This MR describes why these changes were made.
- [x] This MR is into the correct branch (usually 'main').
- [x] Comment added to the relevant Jira ticket(s) with a link to this MR.
- [x] The relevant Jira ticket has been moved to 'Peer Review' (may be N/A if a Jira ticket is associated with multiple MRs)
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.).
- [x] Ensure automated tests pass successfully.

**Final Merger**
- [ ] The necessary number of reviews/approvals have been received on this PR and all checklists have been completed.
- [ ] The relevant Jira ticket has been moved to 'Done' (may N/A if a Jira ticket is associated with multiple MRs)