### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.12.0
+
+### Breaking Changes by @vanessuniq in https://github.com/inferno-framework/davinci-pas-test-kit/pull/24:
+* **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
+* **Inferno Core Update:** Bumped to version `0.6`.
+* **Gemspec Updates:**
+  * Switched to `git` for specifying files.
+  * Added `presets` to the gem package.
+  * Updated any test kit dependencies
+* **Test Kit Metadata:** Implemented Test Kit metadata for Inferno Platform.
+* **Environment Updates:** Updated Ruby version in the Dockerfile and GitHub Actions workflow.
+
+
 # 0.11.1
 
 * FI-3301: SuiteEndpoints by @tstrass in https://github.com/inferno-framework/davinci-pas-test-kit/pull/21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    davinci_pas_test_kit (0.11.1)
+    davinci_pas_test_kit (0.12.0)
       inferno_core (~> 0.6.2)
 
 GEM
@@ -134,7 +134,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.2)
+    inferno_core (0.6.4)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -172,12 +172,12 @@ GEM
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     language_server-protocol (3.17.0.3)
-    logger (1.6.5)
+    logger (1.6.6)
     method_source (1.1.0)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0204)
+    mime-types-data (3.2025.0220)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     multi_json (1.15.0)
@@ -191,14 +191,14 @@ GEM
       mustermann (= 1.1.2)
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.2)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.18.2-arm64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.2-x86_64-linux-gnu)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)

--- a/lib/davinci_pas_test_kit/version.rb
+++ b/lib/davinci_pas_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module DaVinciPASTestKit
-  VERSION = '0.11.1'
-  LAST_UPDATED = '2025-02-04' # TODO: update next release
+  VERSION = '0.12.0'
+  LAST_UPDATED = '2025-02-25'
 end


### PR DESCRIPTION
## Breaking Changes:
- **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
- **Inferno Core Update:** Bumped to version `0.6`.
- **Gemspec Updates:**
  - Switched to `git` for specifying files.
  - Added `presets` to the gem package.
  - Updated any test kit dependencies
- **Test Kit Metadata:** Implemented Test Kit metadata for Inferno Platform.
- **Environment Updates:** Updated Ruby version in the Dockerfile and GitHub Actions workflow.
