### PR TITLE
Fix expired token responses

### DIFF
--- a/lib/davinci_pas_test_kit/endpoints/claim_endpoint.rb
+++ b/lib/davinci_pas_test_kit/endpoints/claim_endpoint.rb
@@ -88,7 +88,7 @@ module DaVinciPASTestKit
 
     def update_result
       if UDAPSecurityTestKit::MockUDAPServer.request_has_expired_token?(request)
-        UDAPSecurityTestKit::MockUDAPServer.update_response_for_expired_token(response)
+        UDAPSecurityTestKit::MockUDAPServer.update_response_for_expired_token(response, 'Bearer token')
         return
       end
 

--- a/lib/davinci_pas_test_kit/endpoints/subscription_create_endpoint.rb
+++ b/lib/davinci_pas_test_kit/endpoints/subscription_create_endpoint.rb
@@ -16,7 +16,7 @@ module DaVinciPASTestKit
 
     def make_response
       if UDAPSecurityTestKit::MockUDAPServer.request_has_expired_token?(request)
-        update_response_for_expired_token(response)
+        UDAPSecurityTestKit::MockUDAPServer.update_response_for_expired_token(response, 'Bearer token')
         return
       end
 

--- a/lib/davinci_pas_test_kit/endpoints/subscription_status_endpoint.rb
+++ b/lib/davinci_pas_test_kit/endpoints/subscription_status_endpoint.rb
@@ -16,7 +16,7 @@ module DaVinciPASTestKit
 
     def make_response
       if UDAPSecurityTestKit::MockUDAPServer.request_has_expired_token?(request)
-        update_response_for_expired_token(response)
+        UDAPSecurityTestKit::MockUDAPServer.update_response_for_expired_token(response)
         return
       end
 


### PR DESCRIPTION
# Summary

Fixed a bug where PAS endpoints were failing to generate responses when the token was expired.

# Testing Guidance

- Run an instance of the PAS client tests using SMART authentication.
- Run the Registration tests providing the following inputs
  - client id = smart_client_test_demo
  - SMART Confidential Asymmetric JSON Web Key Set (JWKS) = http://localhost:4567/custom/smart_stu2_2/.well-known/jwks.json
- Run the approval workflow tests
- When the wait dialog is active, use postman to post a request to http://localhost:4567/custom/davinci_pas_client_suite_v201/fhir/Claim/$submit with `Bearer eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc0NjY0ODAwLCJub25jZSI6IjBiMDllZjRmNDY5MjcxOGIifQ` in the Authorization header (expired token).  Confirm that an error is returned indicating an expired token (the typo in the error is expected and is in the process of being fixed in the smart test kit)/