### PR TITLE
FI-3497: Check for correct adjudication decision code

### DIFF
--- a/lib/davinci_pas_test_kit/custom_groups/v2.0.1/claim_response_decision/pas_claim_response_decision_test.rb
+++ b/lib/davinci_pas_test_kit/custom_groups/v2.0.1/claim_response_decision/pas_claim_response_decision_test.rb
@@ -10,14 +10,14 @@ module DaVinciPASTestKit
       id :prior_auth_claim_response_decision_validation
       title 'Server response includes the expected decision code in the ClaimResponse instance'
       description %(
-        This test aims to confirm that the decision in the returned ClaimResponse matches
+        This test checks that the decision in the returned ClaimResponse matches
         the decision code required for the workflow under examination.
       )
       uses_request :pa_submit
 
       run do
-        adjudication_code_present = resource.resourceType == 'Bundle' && resource.entry.any? do |entry|
-          entry.resource.resourceType == 'ClaimResponse' && entry.resource.item.any? do |item|
+        adjudication_code_present = resource&.resourceType == 'Bundle' && resource.entry.any? do |entry|
+          entry.resource&.resourceType == 'ClaimResponse' && entry.resource.item.any? do |item|
             item.adjudication.any? do |adjudication|
               adjudication.extension.any? do |adjudication_ext|
                 next unless adjudication_ext.url == 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewAction'
@@ -25,7 +25,7 @@ module DaVinciPASTestKit
                 adjudication_ext.extension.any? do |review_action_ext|
                   next unless review_action_ext.url == 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewActionCode'
 
-                  review_action_ext.valueCodeableConcept.coding.any? do |coding|
+                  review_action_ext.valueCodeableConcept&.coding&.any? do |coding|
                     coding.system == 'https://codesystem.x12.org/005010/306' &&
                       coding.code == X12_ADJUDICATION_CODES[use_case.to_sym]
                   end

--- a/lib/davinci_pas_test_kit/custom_groups/v2.0.1/claim_response_decision/pas_claim_response_decision_test.rb
+++ b/lib/davinci_pas_test_kit/custom_groups/v2.0.1/claim_response_decision/pas_claim_response_decision_test.rb
@@ -1,91 +1,42 @@
-# require 'securerandom' //used for attestation experiment - see below
-# require_relative '../../../urls' // used for attestation experiment - see below
-
 module DaVinciPASTestKit
   module DaVinciPASV201
     class PasClaimResponseDecisionTest < Inferno::Test
-      # include URLs // used for attestation experiment - see below
+      X12_ADJUDICATION_CODES = {
+        approval: 'A1',
+        denial: 'A3',
+        pended: 'A4'
+      }.freeze
 
       id :prior_auth_claim_response_decision_validation
       title 'Server response includes the expected decision code in the ClaimResponse instance'
       description %(
         This test aims to confirm that the decision in the returned ClaimResponse matches
         the decision code required for the workflow under examination.
-        This test is not yet implemented due to limitations in the IG (see details
-        [here](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md#testing-limitations)).
-        It is currently optional and will always be skipped, but will be implemented in the future.
       )
       uses_request :pa_submit
-      optional # optional and skipped until implemented
-
-      def status
-        if use_case == 'approval'
-          'approved'
-        else
-          use_case == 'denial' ? 'denied' : 'pended'
-        end
-      end
 
       run do
-        skip
-        # Experiment with extraction of statuses and use in an attestation
-        # Not used due to the following problems:
-        # - no real clients to test with
-        # - how to express the location we're looking for? The spec never mentions it explicitly.
-        #
-        # # Extract the response status
-        # status_values = []
-        # if resource.resourceType == 'Bundle'
-        #   resource.entry.each do |one_entry|
-        #     next unless one_entry.resource.resourceType == 'ClaimResponse'
-        #
-        #     one_entry.resource.item.each do |one_item|
-        #       one_item.adjudication.each do |one_adjudication|
-        #         one_adjudication.extension
-        #           .select { |ext| ext.url == 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewAction' }
-        #           .each do |review_action_ext|
-        #             review_action_ext.extension.select { |ext| ext.url == 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewActionCode' }
-        #               .each do |review_action_code_ext|
-        #                 review_action_code_ext.valueCodeableConcept.coding.select { |coding| coding.system == 'https://codesystem.x12.org/005010/306' }
-        #                   .each do |one_code|
-        #                     if one_code.code
-        #                       status_values << "#{one_code.code}#{one_code.display ? " (#{one_code.display})" : ''}"
-        #                     end
-        #                   end
-        #               end
-        #           end
-        #       end
-        #     end
-        #   end
-        # end
-        #
-        # assert !status_values.empty?, 'No status values found **where??**'
-        #
-        # # Attestation
-        # attestation_key = SecureRandom.uuid
-        # status_display = status_values.reduce('') { |result, status| result + "- #{status}\n" }
-        # wait(
-        #   identifier: attestation_key,
-        #   message: %(
-        #     **Status Validation for `#{status}`**:
-        #
-        #     The following adjudication status
-        #     #{status_values.length > 1 ? 'values were' : 'value was'}
-        #     found in the response **where??**:
-        #
-        #     #{status_display}
-        #
-        #     I attest that
-        #     #{status_values.length > 1 ? 'one of the status values' : 'the status value'}
-        #     returned by the server indicates that the request was #{status}
-        #
-        #     [Click here](#{resume_pass_url}?token=#{attestation_key}) if the above statement is **true**.
-        #
-        #     [Click here](#{resume_fail_url}?token=#{attestation_key}) if the above statement is **false**.
-        #   )
-        # )
-        #
-        # end of experiment with attestation code
+        adjudication_code_present = resource.resourceType == 'Bundle' && resource.entry.any? do |entry|
+          entry.resource.resourceType == 'ClaimResponse' && entry.resource.item.any? do |item|
+            item.adjudication.any? do |adjudication|
+              adjudication.extension.any? do |adjudication_ext|
+                next unless adjudication_ext.url == 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewAction'
+
+                adjudication_ext.extension.any? do |review_action_ext|
+                  next unless review_action_ext.url == 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-reviewActionCode'
+
+                  review_action_ext.valueCodeableConcept.coding.any? do |coding|
+                    coding.system == 'https://codesystem.x12.org/005010/306' &&
+                      coding.code == X12_ADJUDICATION_CODES[use_case.to_sym]
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        assert adjudication_code_present, 'Claim Response did not contain expected adjudication status ' \
+                                          "code '#{X12_ADJUDICATION_CODES[use_case.to_sym]}'"
       end
     end
   end


### PR DESCRIPTION
# Summary

In the server suite, implement the test to check for the correct adjudication decision code, depending on the workflow.

# Testing Guidance

Run each of the workflow groups in the Server Suite and verify expected results:
- The reference server responses do not include the codes, so the tests should fail when run with the reference server preset
- The tests should pass if you run it against the PAS Client Suite (you can reuse the canned request bodies from the reference server preset)