### PR TITLE
Generated documentation following us core and g10 documentation as best practice examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Da Vinci Prior Authorization Support (PAS) v2.0.1 Test Kit
+# Da Vinci Prior Authorization Support (PAS) Test Kit
 
-The Da Vinci Prior Authorization Support (PAS) STU 2.0.1 Test Kit validates the 
+The **Da Vinci Prior Authorization Support (PAS) STU 2.0.1 Test Kit** validates the 
 conformance of systems to the PAS STU 2.0.1 FHIR IG. The test kit includes
 suites targeting each of the actors from the specification:
 
@@ -15,133 +15,90 @@ for conformance and in aggregate to determine that the full set of features is
 supported.
 
 This test kit is [open source](#license) and freely available for use or
-adoption by the health IT community including EHR vendors, health app
+adoption by the health IT community including EHR vendors, payer systems, health app
 developers, and testing labs. It is built using the [Inferno
 Framework](https://inferno-framework.github.io/). The Inferno Framework is
 designed for reuse and aims to make it easier to build test kits for any
 FHIR-based data exchange.
 
+For comprehensive documentation, including detailed walkthroughs, overviews, and
+technical references, please see the [Da Vinci PAS Test Kit
+Documentation](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/).
+
+## Getting Started
+
+ASTP hosts a [public
+instance](https://inferno.healthit.gov/suites/g10_certification) of this test
+kit that developers and testers are welcome to use. However, users are
+encouraged to download and run this tool locally to allow testing within private
+networks and to avoid being affected by downtime of this shared resource.
+Please see the [Local Installation
+Instructions](#local-installation-instructions) section below for more
+information.
+
 ## Status
 
-These tests are a **DRAFT** intended to allow PAS implementers to perform 
+These tests are a **DRAFT** and are intended to allow PAS implementers to perform 
 preliminary checks of their implementations against PAS IG requirements and provide 
 feedback on the tests. Future versions of these tests may validate other 
 requirements and may change how these are tested.
 
-Additional details on the IG requirements that underlie this test kit, including those 
-that are not currently tested, can be found in [this spreadsheet](lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx). The spreadsheet includes
+Additional details on the IG requirements that underlie this test kit, including
+those that are not currently tested, can be found in [this
+spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/raw/refs/heads/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx).
+The spreadsheet includes:
 
 - a list of requirements extracted from the IG.
 - the requirements tested by this DRAFT test kit.
 - an analysis of which requirements are testable, including areas where testable requirements are weak or unclear.
 
-## Test Scope and Limitations
+## Getting Started
 
-Neither the server nor client test suite included test the full scope of the PAS IG.
-Documentation of what is currently tested and what is out of scope and why can be
-found in the suite descriptions when the tests are run, or within this repository
-for the [server](lib/davinci_pas_test_kit/docs/server_suite_description_v201.md#testing-limitations)
-and [client](lib/davinci_pas_test_kit/docs/client_suite_description_v201.md#testing-limitations).
+ASTP hosts a [public
+instance](https://inferno.healthit.gov/test-kits/davinci-pas/) of this test
+kit that developers and testers are welcome to use. However, users are
+encouraged to download and run this tool locally to allow testing within private
+networks and to avoid being affected by downtime of this shared resource.
+Please see the [Local Installation
+Instructions](#local-installation-instructions) section below for more
+information.
 
-### In-Scope Requirements
+Detailed step-by-step instructions for running the tests can be found in our walkthrough guides:
+- [Client Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Walkthrough)
+- [Server Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough)
 
-At a high-level, in-scope requirements include:
+Additional information is provided in the [Da Vinci PAS Test Kit documentation](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/).
 
-- The ability of the system to participate in end-to-end prior authorization
-  workflows, including those resulting in approval or denial, including cases
-  where the request goes through a pending status to allow for additional time
-  for the decision to be made.
-- The ability of the system to produce and receive (currently server tests only)
-  all PAS-defined profiles and their must support elements.
+## Local Installation Instructions
 
-### Out-of-Scope Requirements
-
-Out of scope requirements from the IG that are not yet tested include:
-
-- Subscriptions (see details [here](https://hl7.org/fhir/us/davinci-pas/STU2/specification.html#subscription))
-- Prior Authorization update workflows (see details [here](https://hl7.org/fhir/us/davinci-pas/STU2/specification.html#updating-authorization-requests))
-- Requests for additional information handled through the CDex framework (see details [here](https://hl7.org/fhir/us/davinci-pas/STU2/additionalinfo.html))
-- PDF, CDA, and JPG attachments (see details in the 3rd paragraph [here](https://hl7.org/fhir/us/davinci-pas/STU2/specification.html#prior-authorization-submission))
-- US Core profile support for supporting information (see details [here](https://hl7.org/fhir/us/davinci-pas/STU2/specification.html#integration-with-other-implementation-guides))
-- (Server) Inquiry matching and subsetting logic (see details in the 2nd paragraph and 2 bullet [here](https://hl7.org/fhir/us/davinci-pas/STU2/specification.html#prior-authorization-inquiries))
-- (Server) Inquiry requests from non-submitting systems (see details in the 3rd paragraph [here](https://hl7.org/fhir/us/davinci-pas/STU2/specification.html#pended-authorization-responses))
-- (Server) Collection and dissemination of metrics (see details [here](https://hl7.org/fhir/us/davinci-pas/STU2/metrics.html))
-- (Client) The ability to handle responses containing all PAS-defined profiles and must support elements (see details under the 3rd bullet [here](https://hl7.org/fhir/us/davinci-pas/STU2/background.html#must-support))
-- (Client) Most details requiring manual review of the client system, e.g., the requirement that clinicians can update details of the prior authorization request before submitting them (see details in the 1st paragraph [here](https://hl7.org/fhir/us/davinci-pas/STU2/usecases.html#submit-prior-authorization))
-
-### Limitations
-
-A primary limitation of these tests involves the proprietary nature of the X12 specification that the PAS IG relies upon. See details at the top of the 
-[IG home page](https://hl7.org/fhir/us/davinci-pas/STU2/index.html). This reliance 
-on proprietary information that is not publicly available means that this test kit:
-
-- Cannot verify the correct usage of X12-based terminology: terminology requirements for all elements bound to X12
-  value sets will not be validated
-- Cannot verify the meaning of codes: validation that a given response conveys something specific, e.g., approval
-  or pending, is not performed
-- Cannot verify matching semantics on inquiries: no checking of the identity of the ClaimResponse returned for an
-  inquiry, e.g., that it matches the input or the original request.
-
-These limitations may be removed in future versions of these tests. In the meantime, testers should consider these
-requirements to be verified through attestation and should not represent their systems to have passed these tests
-if these requirements are not met.
-
-## How to Run
-
-Use either of the following methods to run the suites within this test kit.
-If you would like to try out the tests but don’t have a PAS implementation, 
-the test home pages include instructions for trying out the tests, including
-
-- For server testing: a [public reference implementation](https://prior-auth.davinci.hl7.org/fhir)
-  ([code on github](https://github.com/HL7-DaVinci/prior-auth))
-- For client testing: a [sample postman collection](lib/davinci_pas_test_kit/docs/demo/PAS%20Client%20Suite%20Demonstration.postman_collection.json)
-
-Detailed instructions can be found in the suite descriptions when the tests
-are run, or within this repository for the 
-[server](lib/davinci_pas_test_kit/docs/server_suite_description_v201.md#running-the-tests) and
-[client](lib/davinci_pas_test_kit/docs/client_suite_description_v201.md#running-the-tests).
-
-### ONC Hosted Instance
-
-You can run the PAS test kit via the [ONC Inferno](https://inferno.healthit.gov/test-kits/davinci-pas/) website by choosing the “Da Vinci Prior Authorization Support (PAS) v2.0.1” test kit.
-
-### Local Inferno Instance
-
-- Download the source code from this repository.
+- [Download an official release](https://github.com/inferno-framework/davinci-pas-test-kit/releases) of this test kit.
 - Open a terminal in the directory containing the downloaded code.
 - In the terminal, run `setup.sh`.
 - In the terminal, run `run.sh`.
 - Use a web browser to navigate to `http://localhost`.
 
+More information on using Inferno Test Kits is available on the [Inferno
+Framework documentation site](https://inferno-framework.github.io/docs).
+
+### Multi-user Installations
+
+The default configuration of this test kit uses SQLite for data persistence and
+is optimized for running on a local machine with a single user. For
+installations on shared servers that may have multiple tests running
+simultaneously, please [configure the installation to use
+PostgreSQL](https://inferno-framework.github.io/inferno-core/deployment/database.html#postgresql)
+to ensure stability in this type of environment.
+
 ## Providing Feedback and Reporting Issues
 
 We welcome feedback on the tests, including but not limited to the following areas:
 - Validation logic, such as potential bugs, lax checks, and unexpected failures.
-- Requirements coverage, such as requirements that have been missed, tests that necessitate features that the IG does not require, or other issues with the [interpretation](lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx) of the IG's requirements.
+- Requirements coverage, such as requirements that have been missed, tests that necessitate features that the IG does not require, or other issues with the interpretation of the IG's requirements.
 - User experience, such as confusing or missing information in the test UI.
 
-Please report any issues with this set of tests in the issues section of this repository.
-
-## Development
-
-To make updates and additions to this test kit, see the 
-[Inferno Framework Documentation](https://inferno-framework.github.io/docs/),
-particularly the instructions on 
-[development with Ruby](https://inferno-framework.github.io/docs/getting-started/#development-with-ruby).
-
-### Test Generation
-
-The Davinci PAS Test Kit has an implemented test generator that create some of the
-tests in this kit from the capability statement and profiles in the IG. It
-extracts necessary data elements from Davinci Prior Authorization Support Implementation Guide archive files and generates tests accordingly. The repo currently contains
-suites for IG versions 2.0.1.
-
-To generate a test suite for a different Davinci PAS IG version:
-
-- Navigate to `DAVINCI-PAS-Test-Kit/lib/davinci_pas_test_kit/igs/`
-- Drop your package.tgz file for the IG version into this folder. You may want to rename it before hand.
-- Run the command `bundle exec rake pas:generate` to run the generator.
-- Run Inferno and verify that your new suite was generated and is available as an option
+Please report any issues with this set of tests in the [issues
+section](https://github.com/inferno-framework/da-vinci-pas-test-kit/issues)
+section of this repository.
 
 ## License
 

--- a/docs/Client-Details.md
+++ b/docs/Client-Details.md
@@ -1,8 +1,8 @@
+# Client Suite Implementation Details
+
 The Da Vinci PAS Test Kit Client Suite validates the conformance of client
 systems to the STU 2 version of the HL7® FHIR®
 [Da Vinci Prior Authorization Support Implementation Guide](https://hl7.org/fhir/us/davinci-pas/STU2/).
-
-## Scope
 
 These tests are a **DRAFT** intended to allow PAS client implementers to perform
 preliminary checks of their clients against PAS IG requirements and [provide
@@ -10,12 +10,13 @@ feedback](https://github.com/inferno-framework/davinci-pas-test-kit/issues)
 on the tests. Future versions of these tests may validate other
 requirements and may change the test validation logic.
 
-## Test Methodology
+## Technical Implementation
 
-Inferno will simulate a PAS server for the client under test to interact with. The client
-will be expected to initiate requests to the server and demonstrate its ability to react
-to the returned responses. Over the course of these interactions,
-Inferno will seek to observe conformant handling of PAS requirements, including
+In this test suite, Inferno simulates a PAS server for the client under test to
+interact with. The client will be expected to initiate requests to the server
+and demonstrate its ability to react to the returned responses. Over the course
+of these interactions, Inferno will seek to observe conformant handling of PAS
+requirements, including:
 - The ability of the client to initiate a prior authorization submission and react to
     - The approval of the request
     - The denial of the request
@@ -31,6 +32,15 @@ IG requirements individually and used in aggregate to determine whether
 required features and functionality are present. HL7® FHIR® resources are
 validated with the Java validator using `tx.fhir.org` as the terminology server.
 
+Inferno contains basic logic to generate approval, denial, and pended responses, along with a
+notification that a final decision was made, as a part of the above workflows.
+These responses are based on examples available in the PAS Implementation Guide
+and are conformant, but may not meet the needs of actual implementations. Thus,
+testers may provide Inferno with specific responses for Inferno to echo. If responses
+are provided, Inferno will check them for conformance to ensure that they demonstrate
+a fully conformant exchange.
+
+
 ### Responses
 
 Inferno contains basic logic to generate approval, denial, and pended responses, along with a
@@ -40,6 +50,7 @@ and are conformant, but may not meet the needs of actual implementations. Thus,
 testers may provide Inferno with specific responses for Inferno to echo. If responses
 are provided, Inferno will check them for conformance to ensure that they demonstrate
 a fully conformant exchange.
+
 
 ### Authentication
 
@@ -64,181 +75,6 @@ If the client under test does not support either of these standards-based method
 may instead attest to other authentication capabilities. In this case, the client will authenticate
 by sending requests to dedicated PAS endpoints created by Inferno for use during the testing session.
 To reduce configuration burden, the dedicated endpoints can be reused in subsequent sessions.
-
-## Running the Tests
-
-### Quick Start
-
-To execute a simple set of tests with minimal setup and input, perform an approval workflow using
-inferno-generated responses and dedicated session-specific endpoints with the following steps:
-
-1. Create a Da Vinci PAS Client Suite v2.0.1 session using the "Other Authentication" option
-   for the Client Security Type.
-1. Select the "Client Registration" group from the list at the left and and click
-   the "RUN TESTS" button in the upper right.
-1. Optionally provide a value for the **Session-specific URL path extension** input to
-   specify the extra path for the dedicated session endpoint or leave blank to let
-   Inferno generate a value for you. Then click the "SUBMIT" button at the bottom right.
-1. Attest to an alternate authentication approach in the wait dialog that appears and
-   then configure your client to connect to the Inferno FHIR server subsequently displayed
-   and click the link continue.
-1. Select the "Approval Workflow" group from the list at the left and click
-   the "RUN TESTS" button in the upper right.
-1. Click the "SUBMIT" button at the bottom right of the input dialog that appears.
-1. Submit a PAS prior authorization request to the endpoint shown in the wait
-   dialog that appears.
-1. When another wait dialog appears, check your system to see whether Inferno's response
-   was interpreted as an approval or not and click the appropriate link in the dialog.
-1. Review the results including any errors or warnings found when checking the conformance
-   of the request or the generated response.
-
-Group "Denial Workflow" can be run in the same manner. To run the "Pended Workflow" group,
-first run the "Subscription Setup" group, during which the client system will submit a
-Subscription so that Inferno knows how and where to send a notification that a decision has
-been rendered on a pended prior authorization request. Then proceed to execute the 
-"Pended Workflow" group and follow the instructions in the dialogs that appear.
-
-### Postman-based Demonstration
-
-If you do not have a PAS client but would like to try the tests out, you can use
-[this postman collection](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/docs/demo/PAS%20Client%20Suite%20Demonstration.postman_collection.json)
-to make requests against Inferno and see the mocked responses provided by Inferno. To use, load
-the collection into the [Postman app](https://www.postman.com/downloads/) and follow these steps:
-
-1. Start a Da Vinci PAS Client Suite v2.0.1 session from the [PAS Test Kit page on 
-   inferno.healthit.gov](https://inferno.healthit.gov/test-kits/davinci-pas/),
-   choosing the "Other Authentication" option for the Client Security Type.
-2. Click the *Run All Tests* button in the upper right hand corner of the suite.
-3. Client Registration
-   - In the **Session-specific URL path extension** input, put a short alpha string, such as `demo`
-   - In Postman, select the *PAS Client Suite Demonstration* Collection in postman and go to the "Variables" tab 
-     (see the collection's Overview tab for more details on what the variables control).
-   - In the current value for the **session_url_path** variable, put the same value as in the
-     **Session-specific URL path extension** input, surrounded by `/`, e.g., `/demo/` and
-     save the collection.
-   - Back in Inferno, click the "SUBMIT" button and click the links to continue the tests
-     in the next two wait dialogs until a **Subscription Creation Test** wait dialog appears.
-1. In Postman, select the *Create Subscription Request* in the *Subscription Setup* folder
-   and click the "Send" button in the upper right.
-1. Back in Inferno, the wait dialog should disappear and a new **Approval Workflow Test** wait
-   dialog will appear.
-1. In Postman, select the *Prior Auth Request For Approval* in the *Approval Workflow* folder
-   and click the "Send" button in the upper right.
-1. Back in Inferno, the wait dialog should disappear and a new attestation wait dialog will
-   appear asking to confirm the system's interpretation of the "Approved" response. Check that
-   the response from the last step in Postman contains the string "Certified in total" and respond
-   to the attestation. The wait dialog should disappear and a new **Denial Workflow Test** wait
-   dialog will appear.
-1. In Postman, select the *Prior Auth Request For Denial* in the *Denial Workflow* folder
-   and click the "Send" button in the upper right.
-1. Back in Inferno, the wait dialog should disappear and a new attestation wait dialog will
-   appear asking to confirm the system's interpretation of the "Denied" response. Check that
-   the response from the last step in Postman contains the string "Not Certified" and respond
-   to the attestation. The wait dialog should disappear and a new **Pended Workflow Test** wait
-   dialog will appear.
-1. In Postman, select the *Prior Auth Request For Pended* entry under the *Pended Workflow* folder in the
-   and click the "Send" button in the upper right.
-1. Search in the response returned to Postman for the string "Pending" which indicates the prior
-   auth request was pended and a final decision will be made later. You'll use this information in
-   a later attestation.
-1. Meanwhile, Inferno sent a notification indicating that a final decision was made (5-10 seconds
-   after the prior auth request). If interested in seeing the notification message, it can be found
-   on the [notifications 
-   page](https://subscriptions.argo.run/subscriptions/notifications-received?store=r4) for the 
-   [Argonaut Subscriptions Reference Implementation](https://subscriptions.argo.run/), which
-   hosts a notification endpoint that is used to receive Subscription notifications for this demo.
-   Note that when looking for recent notifications, **Received** timestamps are in UTC which is
-   5 hours ahead of Eastern Standard Time (4 hours ahead of Eastern Daylight Time).
-1. In Postman, select the *Prior Auth Inquiry for Pended* entry under the *Pended Workflow* folder in the
-   and click the "Send" button in the upper right.
-1. Search in the response returned to Postman for the string "Certified in total" which indicates the prior
-   auth request was approved. You'll use this information in a later attestation.
-1. Back in Inferno, scroll down in wait dialog and click the "click here to complete the test"
-   link to allow Inferno to evaluate the pended workflow.
-1. The next two attestations ask whether the system displayed the claim as pended and approved at the
-   appropriate points in the workflow. Attest based on whether the correct strings were found in the
-   responses in the previous steps.
-1. Two additional "User Action" dialogs will appear requesting additional `$submit` and `$inquire`
-   requests to demonstrate must support elements. This demo does not have any additional requests
-   and does not attempt to demonstrate all must support elements, so click the link to indicate
-   you are done submitting requests for each. Note that requests submitted during the workflow section
-   will be evaluated and you can inspect the results under the Demonstrate Element Support test
-   to see both passing and failing tests.
-1. Once Inferno finishes evaluating the requests, the test will complete allowing you to review the
-   results, including warning and error messages as well as requests associated with each test.
-
-The tests are expected to pass with the exception of the Must Support tests.
-
-#### Optional Demo Modification: full-resource Subscription
-
-This demo uses `id-only` notifications for Pended workflow. To see a demonstration of `full-resource`
-notifications, replace the string `id-only` in the "Create Subscription Request" entry under the 
-"Subscription Setup" folder in the collection with the string `full-resource` (found in an extension
-under the `_payload` element).
-
-#### Optional Demo Modification: SMART Backend Services Auth
-
-To use SMART Backend Services with the demo, choose the "SMART Backend Services" Client Security Type
-option and replace the 3. Client Registration steps above with the following:
-
-- In the **SMART JSON Web Key Set (JWKS)** input, put `https://inferno.healthit.gov/suites/custom/smart_stu2_2/.well-known/jwks.json`
-- In the **Client Id** input, put `pas_demo_smart`
-- Click the **SUBMIT** button
-- A wait dialog will display asking the tester to confirm configuration of the client. Note the
-  FHIR endpoint and client id details
-- Start an instance of the SMART App Launch STU2.2 test suite.
-- Select the **3** Backend Services group from the list at the left and the click the "RUN TESTS"
-  button in the upper right.
-- Fill in the following input values and then click "SUBMIT":
-  - **FHIR Endpoint**: from the wait dialog in the PAS Client suite
-  - **Scopes**: any scope string, e.g., `system/*.rs`
-  - **Client Id**: same value as in the corresponding input to the PAS Client tests, also displayed
-    in the wait dialog
-- Find the access token to use for the data access request by opening test **3.2.05** Authorization
-  request succeeds when supplied correct information, click on the "REQUESTS" tab, clicking on the "DETAILS"
-  button, and expanding the "Response Body". Copy the "access_token" value, which will be a ~100 character
-  string of letters and numbers (e.g., eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc0MzUxNDk4Mywibm9uY2UiOiJlZDI5MWIwNmZhMTE4OTc4In0)
-- In Postman, select the *PAS Client Suite Demonstration* Collection in postman and go to the "Variables" tab 
-  (see the collection's Overview tab for more details on what the variables control).
-- In the current value for the **access_token** variable, put access token value copied from the SMART tests.
-  Make sure that the **session_url_path** variable has a current value of `/`.
-- Back in Inferno, click link in the wait dialog confirming the configuration to continue the tests.
-- A **Subscription Creation Test** wait dialog will appear.
-
-Continue the tests according to step 4 around Subscription creation in the above instructions.
-
-In this demonstration, the "Verify SMART Token Requests" test will also fail due to invalid
-token requests sent intentionally by the SMART Backend Services server tests.
-
-#### Optional Demo Modification: UDAP Client Credentials Auth
-
-To use the UDAP Client Credentials with the demo, choose the "UDAP B2B Client Credentials" Client
-Security Type option and replace the 3. Client Registration steps above with the following:
-
-- In the **UDAP Client URI** input, put `http://localhost:4567/custom/udap_security/fhir`
-- Click the **SUBMIT** button and a wait dialog will display asking the tester to perform UDAP dynamic
-  registration. Note the FHIR server endpoint displayed in the dialog.
-- Start an instance of the UDAP Security Server test suite.
-- Select the "Demo: Run Against the UDAP Security Client Suite" preset from the dropdown in the upper left.
-- Select the **2** UDAP Client Credentials Flow group from the list at the left and the click the "RUN ALL TESTS"
-  button in the upper right.
-- Update the **FHIR Server Base URL** input value to be the FHIR server endpoint from the wait dialog
-  in the PAS Client suite and then click "SUBMIT"
-- Once the tests have completed, find the access token to use for the data access request by opening
-  test **2.3.01** OAuth token exchange request succeeds when supplied correct information, click
-  on the "REQUESTS" tab, clicking on the "DETAILS" button, and expanding the "Response Body".
-  Copy the "access_token" value, which will be a ~100 character string of letters and numbers (e.g., eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc0MzUxNDk4Mywibm9uY2UiOiJlZDI5MWIwNmZhMTE4OTc4In0)
-- In Postman, select the *PAS Client Suite Demonstration* Collection in postman and go to the "Variables" tab 
-  (see the collection's Overview tab for more details on what the variables control).
-- In the current value for the **access_token** variable, put access token value copied from the SMART tests.
-  Make sure that the **session_url_path** variable has a current value of `/`.
-- In the PAS Client suite tab, click the link in the wait dialog to continue the tests. Do the same
-  for the next wait dialog that appears until a **Subscription Creation Test** wait dialog appears.
-
-Continue the tests according to step 4 around Subscription creation in the above instructions.
-
-In this demonstration, the "Verify UDAP Client Credentials Token Requests" test may fail due
-to expired signatures if the test session has taken long enough.
 
 ## Auth Configuration Details
 

--- a/docs/Client-Walkthrough.md
+++ b/docs/Client-Walkthrough.md
@@ -1,0 +1,176 @@
+# Da Vinci PAS Test Kit: Client Testing Walkthrough
+
+This document provides a step-by-step guide for running the Da Vinci PAS Test Kit to test a **client system**. In this scenario, Inferno acts as the PAS server.
+
+## Quick Start
+
+To execute a simple set of tests with minimal setup and input, perform an approval workflow using
+inferno-generated responses and dedicated session-specific endpoints with the following steps:
+
+1. Create a Da Vinci PAS Client Suite v2.0.1 session using the "Other Authentication" option
+   for the Client Security Type.
+1. Select the "Client Registration" group from the list at the left and and click
+   the "RUN TESTS" button in the upper right.
+1. Optionally provide a value for the **Session-specific URL path extension** input to
+   specify the extra path for the dedicated session endpoint or leave blank to let
+   Inferno generate a value for you. Then click the "SUBMIT" button at the bottom right.
+1. Attest to an alternate authentication approach in the wait dialog that appears and
+   then configure your client to connect to the Inferno FHIR server subsequently displayed
+   and click the link continue.
+1. Select the "Approval Workflow" group from the list at the left and click
+   the "RUN TESTS" button in the upper right.
+1. Click the "SUBMIT" button at the bottom right of the input dialog that appears.
+1. Submit a PAS prior authorization request to the endpoint shown in the wait
+   dialog that appears.
+1. When another wait dialog appears, check your system to see whether Inferno's response
+   was interpreted as an approval or not and click the appropriate link in the dialog.
+1. Review the results including any errors or warnings found when checking the conformance
+   of the request or the generated response.
+
+Group "Denial Workflow" can be run in the same manner. To run the "Pended Workflow" group,
+first run the "Subscription Setup" group, during which the client system will submit a
+Subscription so that Inferno knows how and where to send a notification that a decision has
+been rendered on a pended prior authorization request. Then proceed to execute the 
+"Pended Workflow" group and follow the instructions in the dialogs that appear.
+
+### Postman-based Demonstration
+
+If you do not have a PAS client but would like to try the tests out, you can use
+[this postman collection](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/docs/demo/PAS%20Client%20Suite%20Demonstration.postman_collection.json)
+to make requests against Inferno and see the mocked responses provided by Inferno. To use, load
+the collection into the [Postman app](https://www.postman.com/downloads/) and follow these steps:
+
+1. Start a Da Vinci PAS Client Suite v2.0.1 session from the [PAS Test Kit page on 
+   inferno.healthit.gov](https://inferno.healthit.gov/test-kits/davinci-pas/),
+   choosing the "Other Authentication" option for the Client Security Type.
+2. Click the *Run All Tests* button in the upper right hand corner of the suite.
+3. Client Registration
+   - In the **Session-specific URL path extension** input, put a short alpha string, such as `demo`
+   - In Postman, select the *PAS Client Suite Demonstration* Collection in postman and go to the "Variables" tab 
+     (see the collection's Overview tab for more details on what the variables control).
+   - In the current value for the **session_url_path** variable, put the same value as in the
+     **Session-specific URL path extension** input, surrounded by `/`, e.g., `/demo/` and
+     save the collection.
+   - Back in Inferno, click the "SUBMIT" button and click the links to continue the tests
+     in the next two wait dialogs until a **Subscription Creation Test** wait dialog appears.
+1. In Postman, select the *Create Subscription Request* in the *Subscription Setup* folder
+   and click the "Send" button in the upper right.
+1. Back in Inferno, the wait dialog should disappear and a new **Approval Workflow Test** wait
+   dialog will appear.
+1. In Postman, select the *Prior Auth Request For Approval* in the *Approval Workflow* folder
+   and click the "Send" button in the upper right.
+1. Back in Inferno, the wait dialog should disappear and a new attestation wait dialog will
+   appear asking to confirm the system's interpretation of the "Approved" response. Check that
+   the response from the last step in Postman contains the string "Certified in total" and respond
+   to the attestation. The wait dialog should disappear and a new **Denial Workflow Test** wait
+   dialog will appear.
+1. In Postman, select the *Prior Auth Request For Denial* in the *Denial Workflow* folder
+   and click the "Send" button in the upper right.
+1. Back in Inferno, the wait dialog should disappear and a new attestation wait dialog will
+   appear asking to confirm the system's interpretation of the "Denied" response. Check that
+   the response from the last step in Postman contains the string "Not Certified" and respond
+   to the attestation. The wait dialog should disappear and a new **Pended Workflow Test** wait
+   dialog will appear.
+1. In Postman, select the *Prior Auth Request For Pended* entry under the *Pended Workflow* folder in the
+   and click the "Send" button in the upper right.
+1. Search in the response returned to Postman for the string "Pending" which indicates the prior
+   auth request was pended and a final decision will be made later. You'll use this information in
+   a later attestation.
+1. Meanwhile, Inferno sent a notification indicating that a final decision was made (5-10 seconds
+   after the prior auth request). If interested in seeing the notification message, it can be found
+   on the [notifications 
+   page](https://subscriptions.argo.run/subscriptions/notifications-received?store=r4) for the 
+   [Argonaut Subscriptions Reference Implementation](https://subscriptions.argo.run/), which
+   hosts a notification endpoint that is used to receive Subscription notifications for this demo.
+   Note that when looking for recent notifications, **Received** timestamps are in UTC which is
+   5 hours ahead of Eastern Standard Time (4 hours ahead of Eastern Daylight Time).
+1. In Postman, select the *Prior Auth Inquiry for Pended* entry under the *Pended Workflow* folder in the
+   and click the "Send" button in the upper right.
+1. Search in the response returned to Postman for the string "Certified in total" which indicates the prior
+   auth request was approved. You'll use this information in a later attestation.
+1. Back in Inferno, scroll down in wait dialog and click the "click here to complete the test"
+   link to allow Inferno to evaluate the pended workflow.
+1. The next two attestations ask whether the system displayed the claim as pended and approved at the
+   appropriate points in the workflow. Attest based on whether the correct strings were found in the
+   responses in the previous steps.
+1. Two additional "User Action" dialogs will appear requesting additional `$submit` and `$inquire`
+   requests to demonstrate must support elements. This demo does not have any additional requests
+   and does not attempt to demonstrate all must support elements, so click the link to indicate
+   you are done submitting requests for each. Note that requests submitted during the workflow section
+   will be evaluated and you can inspect the results under the Demonstrate Element Support test
+   to see both passing and failing tests.
+1. Once Inferno finishes evaluating the requests, the test will complete allowing you to review the
+   results, including warning and error messages as well as requests associated with each test.
+
+The tests are expected to pass with the exception of the Must Support tests.
+
+#### Optional Demo Modification: full-resource Subscription
+
+This demo uses `id-only` notifications for Pended workflow. To see a demonstration of `full-resource`
+notifications, replace the string `id-only` in the "Create Subscription Request" entry under the 
+"Subscription Setup" folder in the collection with the string `full-resource` (found in an extension
+under the `_payload` element).
+
+#### Optional Demo Modification: SMART Backend Services Auth
+
+To use SMART Backend Services with the demo, choose the "SMART Backend Services" Client Security Type
+option and replace the 3. Client Registration steps above with the following:
+
+- In the **SMART JSON Web Key Set (JWKS)** input, put `https://inferno.healthit.gov/suites/custom/smart_stu2_2/.well-known/jwks.json`
+- In the **Client Id** input, put `pas_demo_smart`
+- Click the **SUBMIT** button
+- A wait dialog will display asking the tester to confirm configuration of the client. Note the
+  FHIR endpoint and client id details
+- Start an instance of the SMART App Launch STU2.2 test suite.
+- Select the **3** Backend Services group from the list at the left and the click the "RUN TESTS"
+  button in the upper right.
+- Fill in the following input values and then click "SUBMIT":
+  - **FHIR Endpoint**: from the wait dialog in the PAS Client suite
+  - **Scopes**: any scope string, e.g., `system/*.rs`
+  - **Client Id**: same value as in the corresponding input to the PAS Client tests, also displayed
+    in the wait dialog
+- Find the access token to use for the data access request by opening test **3.2.05** Authorization
+  request succeeds when supplied correct information, click on the "REQUESTS" tab, clicking on the "DETAILS"
+  button, and expanding the "Response Body". Copy the "access_token" value, which will be a ~100 character
+  string of letters and numbers (e.g., eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc0MzUxNDk4Mywibm9uY2UiOiJlZDI5MWIwNmZhMTE4OTc4In0)
+- In Postman, select the *PAS Client Suite Demonstration* Collection in postman and go to the "Variables" tab 
+  (see the collection's Overview tab for more details on what the variables control).
+- In the current value for the **access_token** variable, put access token value copied from the SMART tests.
+  Make sure that the **session_url_path** variable has a current value of `/`.
+- Back in Inferno, click link in the wait dialog confirming the configuration to continue the tests.
+- A **Subscription Creation Test** wait dialog will appear.
+
+Continue the tests according to step 4 around Subscription creation in the above instructions.
+
+In this demonstration, the "Verify SMART Token Requests" test will also fail due to invalid
+token requests sent intentionally by the SMART Backend Services server tests.
+
+#### Optional Demo Modification: UDAP Client Credentials Auth
+
+To use the UDAP Client Credentials with the demo, choose the "UDAP B2B Client Credentials" Client
+Security Type option and replace the 3. Client Registration steps above with the following:
+
+- In the **UDAP Client URI** input, put `http://localhost:4567/custom/udap_security/fhir`
+- Click the **SUBMIT** button and a wait dialog will display asking the tester to perform UDAP dynamic
+  registration. Note the FHIR server endpoint displayed in the dialog.
+- Start an instance of the UDAP Security Server test suite.
+- Select the "Demo: Run Against the UDAP Security Client Suite" preset from the dropdown in the upper left.
+- Select the **2** UDAP Client Credentials Flow group from the list at the left and the click the "RUN ALL TESTS"
+  button in the upper right.
+- Update the **FHIR Server Base URL** input value to be the FHIR server endpoint from the wait dialog
+  in the PAS Client suite and then click "SUBMIT"
+- Once the tests have completed, find the access token to use for the data access request by opening
+  test **2.3.01** OAuth token exchange request succeeds when supplied correct information, click
+  on the "REQUESTS" tab, clicking on the "DETAILS" button, and expanding the "Response Body".
+  Copy the "access_token" value, which will be a ~100 character string of letters and numbers (e.g., eyJjbGllbnRfaWQiOiJzbWFydF9jbGllbnRfdGVzdF9kZW1vIiwiZXhwaXJhdGlvbiI6MTc0MzUxNDk4Mywibm9uY2UiOiJlZDI5MWIwNmZhMTE4OTc4In0)
+- In Postman, select the *PAS Client Suite Demonstration* Collection in postman and go to the "Variables" tab 
+  (see the collection's Overview tab for more details on what the variables control).
+- In the current value for the **access_token** variable, put access token value copied from the SMART tests.
+  Make sure that the **session_url_path** variable has a current value of `/`.
+- In the PAS Client suite tab, click the link in the wait dialog to continue the tests. Do the same
+  for the next wait dialog that appears until a **Subscription Creation Test** wait dialog appears.
+
+Continue the tests according to step 4 around Subscription creation in the above instructions.
+
+In this demonstration, the "Verify UDAP Client Credentials Token Requests" test may fail due
+to expired signatures if the test session has taken long enough.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,0 +1,79 @@
+# Da Vinci PAS Test Kit Overview
+
+This document provides a high-level overview of the Da Vinci Prior Authorization Support (PAS) Test Kit, its purpose, and general testing approach.
+
+## Purpose
+
+The Da Vinci PAS Test Kit is designed to validate the conformance of healthcare IT systems against [version 2.0.1 of the HL7 FHIR Da Vinci Prior Authorization Support (PAS) Implementation Guide (IG)](https://hl7.org/fhir/us/davinci-pas/STU2/). It helps implementers ensure their systems can correctly participate in electronic prior authorization workflows as defined by the PAS IG.
+
+The test kit is built using the [Inferno Framework](https://inferno-framework.github.io/), an open-source platform for building FHIR-based test kits.
+
+## Test Kit Structure
+
+The PAS Test Kit includes two main test suites:
+
+* **Server Test Suite**: For systems acting as payers (see [Server Details](Server-Details.md) for more information)
+* **Client Test Suite**: For systems acting as providers (see [Client Details](Client-Details.md) for more information)
+
+## General Testing Approach
+
+The test kit validates systems through:
+
+1. **Workflow Simulation**: Tests guide the system through key PAS workflows including:
+   * Prior authorization request submission and response handling
+   * Approval, denial, and pended decision flows
+   * Error condition handling
+
+2. **Data Conformance**:
+   * Validation of must-support elements in PAS-defined FHIR profiles
+   * FHIR resource validation using the official FHIR validator
+   * Verification of proper Bundle structure and references
+
+3. **Authentication**:
+   * Support for SMART Backend Services
+   * UDAP B2B client credentials flow
+   * Other authentication methods via attestation
+
+## Test Scope and Limitations
+
+This test kit is a **DRAFT**. While it covers core aspects of the PAS IG, there are known limitations.
+
+The test kit currently focuses on validating core end-to-end prior authorization
+workflows, including the submission and handling of responses for prior
+authorization requests (approval, denial, pended). It also covers FHIR profile
+conformance, validation of must-support elements as defined in PAS IG profiles,
+basic subscription mechanics for pended request notifications, and core
+authentication flows like SMART Backend Services and UDAP B2B.
+
+Several areas are generally considered out of scope for automated testing. This
+includes the proprietary details of X12 transactions, such as X12-based
+terminology validation, the semantic meaning of X12 codes, and X12-based
+matching logic. Additional workflows and features not currently covered include
+Prior Authorization Updates (`Claim/$update`), comprehensive handling of
+Requests for Additional Information (RFAI), processing of various attachment
+types (PDF, CDA, JPG), full US Core Profile support, and advanced subscription
+details beyond basic mechanics.
+
+For a details on specific specific limitations, detailed requirements, and known
+issues, please consult the following resources: the [Client Testing
+Limitations](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Details#testing-limitations),
+the [Server Testing
+Limitations](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details#testing-limitations),
+the [PAS Requirements Interpretation
+Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx),
+and the project's [GitHub Issues
+page](https://github.com/inferno-framework/davinci-pas-test-kit/issues).
+
+## Conformance Criteria & Interpreting Results
+
+A test run is considered successful if all mandatory tests pass:
+* **Passing Tests**: Indicate expected behavior for specific scenarios
+* **Failing Tests**: Indicate deviations from PAS IG requirements
+* **Warnings**: Highlight potential concerns that require manual review
+* **Skipped Tests**: Occur when prerequisites are not met
+
+Given the known limitations, especially regarding X12, passing all automated tests does **not** solely constitute full PAS IG conformance. Systems should also meet requirements verified through attestation or other means.
+
+For specific testing prerequisites and detailed test descriptions, refer to:
+* [Client Walkthrough](Client-Walkthrough.md)
+* [Server Walkthrough](Server-Walkthrough.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Da Vinci PAS Test Kit Documentation
+
+The **Da Vinci Prior Authorization Support (PAS) Test Kit** is a testing tool
+that is designed to help implementers validate systems against the STU2
+version of the HL7® FHIR® [Da Vinci Prior Authorization Support Implementation
+Guide](https://hl7.org/fhir/us/davinci-pas/STU2/). The following documentation
+provides information on how to use and contribute to this test kit.
+
+## Using this Test Kit
+
+*   **[Getting Started](../tree/main/README.md#getting-started)**: Instructions on how to set up and run the test kit.
+*   **[Test Kit Overview](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Overview)**: A detailed explanation of what the test kit does, its scope, and how its tests are structured.
+*   **[Client Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Walkthrough)**: Step-by-step guide for testing client systems.
+*   **[Server Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough)**: Step-by-step guide for testing server systems.
+
+## Contributing to this Test Kit
+
+*   **[Technical Overview](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Technical-Overview)**: An overview of the test kit's technical design and architecture for developers and contributors.
+*   **[Server Test Generation Guide](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Test-Generation-Guide)**: Information on how server tests are generated and how to maintain this process.
+
+## Reference Documents
+
+*   **[PAS Requirements Interpretation](../tree/main/lib/davinci_pas_test_kit/docs/PAS-Requirements-Interpretation.xlsx)**: Spreadsheet detailing the interpretation of IG requirements for this test kit.
+
+## Support
+
+If you have any problems, please open an issue on our [GitHub Issues page](https://github.com/inferno-framework/davinci-pas-test-kit/issues).

--- a/docs/Server-Details.md
+++ b/docs/Server-Details.md
@@ -1,8 +1,8 @@
+# Server Suite Implementation Details
+
 The Da Vinci PAS Server Suite validates the conformance of server systems 
 to the STU 2 version of the HL7® FHIR® 
 [Da Vinci Prior Authorization Support Implementation Guide](https://hl7.org/fhir/us/davinci-pas/STU2/).
-
-## Scope
 
 These tests are a **DRAFT** intended to allow PAS server implementers to perform 
 preliminary checks of their servers against PAS IG requirements and [provide 

--- a/docs/Server-Walkthrough.md
+++ b/docs/Server-Walkthrough.md
@@ -1,0 +1,63 @@
+# Da Vinci PAS Test Kit: Server Testing Walkthrough
+
+This document provides a step-by-step guide for running the Da Vinci PAS Test Kit to test a **server system (payer)**. In this scenario, Inferno acts as the PAS client.
+
+## 1. Quick Start (Using Public Reference Server Example)
+
+This example uses pre-configured inputs to test against the public Da Vinci PAS reference implementation. This is useful for understanding the test flow.
+
+1.  **Navigate to Inferno**: Open your Inferno instance and select "Da Vinci Prior Authorization Support (PAS) v2.0.1" test kit.
+2.  **Create a Test Session**:
+    *   Choose the "Da Vinci PAS Server Suite v2.0.1".
+3.  **Select Preset**:
+    *   From the "Preset" dropdown menu (usually located in the top-left of the test suite page), select "Prior Authorization Support Reference Implementation".
+    *   This action will automatically populate various input fields, such as the FHIR server endpoint and sample request payloads, with values appropriate for the public reference server.
+4.  **Run All Tests**:
+    *   Click the "Run All Tests" button (typically found in the top-right).
+5.  **Submit Inputs**:
+    *   A dialog will appear showing the pre-filled inputs from the preset. You can review them if you wish.
+    *   Click the "SUBMIT" button (usually at the bottom-right of the dialog).
+6.  **Monitor Execution**:
+    *   Inferno will begin executing the test sequences against the configured reference server. This process includes:
+        *   **Subscription Setup**: Inferno sends a `Subscription` resource (defined in the preset inputs) to the server. The server is expected to process this and be ready to send notifications to an Inferno-hosted endpoint when relevant events occur.
+        *   **Core Workflows (Approval, Denial, Pended, Error)**: Inferno sends various `$submit` and `$inquire` FHIR Bundle requests (also from preset inputs) to the server. It then validates the server's responses for conformance and correctness according to the expected workflow outcome.
+        *   For the pended workflow, after sending a request that should result in a pended status, Inferno will wait for a notification from the server (triggered by the earlier `Subscription`) before proceeding with a `$inquire` request to get the final decision.
+7.  **Review Results**:
+    *   Once all tests have completed, Inferno will display the results.
+    *   **Note**: The public reference server may not always be perfectly aligned with the STU2 version of the PAS IG that these tests target. Therefore, some failures or warnings might be observed when testing against it. This is normal and primarily serves to demonstrate the test execution flow.
+
+## 2. Testing Your Own Server
+
+This section details how to configure and run the tests against your own PAS server implementation.
+
+1.  **Navigate to Inferno**: Open your Inferno instance and select "Da Vinci Prior Authorization Support (PAS) v2.0.1" test kit.
+2.  **Create a Test Session**:
+    *   Choose the "Da Vinci PAS Server Suite v2.0.1".
+3.  **Configure Inputs**:
+    *   When you select a specific test group (e.g., "Approval Workflow") or click "Run All Tests", an input dialog will appear. You **must** provide the following information tailored to your server:
+        *   **FHIR Server Endpoint URL**: The base FHIR URL of your PAS server (e.g., `https://your-pas-server.com/fhir`). Inferno will append `/Claim/$submit`, `/Claim/$inquire`, and `/Subscription` to this base URL.
+        *   **OAuth Credentials / Access Token**: If your server requires OAuth 2.0 authentication for its PAS endpoints, provide a valid Bearer token here. Inferno will include this token in the `Authorization` header of all requests it makes to your server.
+        *   **PAS Submit Request Payload for Approval Response**: A complete JSON-encoded FHIR Bundle. This bundle should be a `$submit` request that, when sent to your server, is expected to result in a prior authorization approval.
+        *   **PAS Submit Request Payload for Denial Response**: A JSON FHIR Bundle for a `$submit` request that should lead to a denial from your server.
+        *   **PAS Submit Request Payload for Pended Response**: A JSON FHIR Bundle for a `$submit` request that should cause your server to return a pended status.
+        *   **PAS Inquire Request Payload for Pended Claim**: A JSON FHIR Bundle for a `$inquire` request. This request should be for the claim that was previously pended, and your server is expected to return the final decision (e.g., approval or denial).
+        *   **PAS Submit Request Payload for Error Response** (Optional but Recommended): A JSON FHIR Bundle for a `$submit` request that is malformed or should otherwise cause your server to return an error (typically an `OperationOutcome`).
+        *   **Additional PAS Submit Request Payloads** (Optional): A JSON array of JSON FHIR Bundles (e.g., `[bundle1, bundle2]`). These are used to test must-support elements more comprehensively by submitting varied requests.
+        *   **Additional PAS Inquire Request Payloads** (Optional): Similar to the above, but for `$inquire` operations.
+        *   **Pended Prior Authorization Subscription**: A JSON FHIR `Subscription` resource body. Inferno will POST this to your server's `/Subscription` endpoint. This `Subscription` should be crafted so that your server sends notifications to Inferno when the pended prior authorization request (from "PAS Submit Request Payload for Pended Response") is updated with a final decision. Inferno will automatically modify the `channel.endpoint` in this provided `Subscription` to its own dynamically generated notification listener URL.
+        *   **Notification Access Token**: If your server, when sending a notification *to* Inferno's endpoint, requires an `Authorization` header with a Bearer token, provide that token here.
+4.  **Run Tests**:
+    *   After configuring the inputs, select a specific test group or "Run All Tests".
+    *   Click the "RUN TESTS" button.
+    *   If you haven't already, fill in all required inputs in the dialog.
+    *   Click "SUBMIT".
+5.  **Monitor and Ensure Server Readiness**:
+    *   Inferno will begin sending requests to your server. Ensure your server is running, accessible from the Inferno instance, and correctly configured to handle PAS requests.
+    *   **For the Pended Workflow**:
+        *   Your server must successfully process the `Subscription` resource POSTed by Inferno.
+        *   When the claim submitted via "PAS Submit Request Payload for Pended Response" is finalized by your server's internal logic, your server must send a notification (as per the active `Subscription`) to the endpoint Inferno provided (visible in the test execution logs or `Subscription` resource details).
+        *   Inferno will wait for this notification before sending the "PAS Inquire Request Payload for Pended Claim".
+6.  **Review Results**:
+    *   After the tests complete, carefully review the results in Inferno. Pay close attention to any failures or warnings, as they indicate potential non-conformance with the PAS IG. The details of each test execution, including requests sent and responses received, can be inspected.
+
+Refer to the [Server Test Suite Description](../tree/main/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md) for more in-depth explanations of each input field, authentication, and specific testing limitations.

--- a/docs/Technical-Overview.md
+++ b/docs/Technical-Overview.md
@@ -1,0 +1,87 @@
+# Da Vinci PAS Test Kit: Technical Overview
+
+This document provides a technical overview of the Da Vinci Prior Authorization Support (PAS) Test Kit, aimed at developers and contributors. It covers test design principles, code organization, related systems, and guidelines for testing code changes.
+
+## Test Design Principles
+
+The PAS Test Kit is built upon the Inferno Framework and adheres to its core design principles:
+
+*   **FHIR-Native**: Tests are designed around FHIR interactions and data models.
+*   **IG-Centric**: Validation is based on the requirements and profiles defined in the Da Vinci PAS Implementation Guide.
+*   **Actor-Based Testing**: Separate test suites target client and server actors, simulating the counterpart system.
+*   **Automated Validation**: Wherever possible, conformance is checked automatically. This includes FHIR resource validation, profile conformance, and workflow logic.
+*   **Transparency**: Test logic and results are intended to be clear and understandable, aiding implementers in identifying issues.
+*   **Extensibility**: The Inferno Framework allows for the creation of custom tests and test suites.
+
+## Code Organization
+
+The primary codebase for the PAS Test Kit resides within the `lib/davinci_pas_test_kit/` directory. Key subdirectories and files include:
+
+*   **`client_suite.rb`**: Defines the main test suite for PAS clients.
+*   **`metadata.rb`**: Contains metadata for the test kit, including its title, description (which appears in the Inferno UI), and suite IDs. This is a crucial file for how the test kit presents itself in the Inferno Framework.
+*   **`version.rb`**: Specifies the version of the test kit.
+*   **`docs/`**: Contains Markdown documentation files that are mirrored to the [GitHub wiki](/inferno-framework/davinci-pas-test-kit/wiki) for this repository.
+*   **`generated/`**: Contains tests and supporting files that are programmatically generated from the PAS Implementation Guide artifacts (like CapabilityStatements and StructureDefinitions). This is a key part of the test kit's strategy to stay aligned with the IG. It's typically structured by IG version.
+*   **`generator/`**: Holds the Ruby scripts and templates responsible for the test generation process. Files like `suite_generator.rb`, `group_generator.rb`, and `must_support_test_generator.rb` are central to this.
+*   **`custom_groups/`**: This directory contains custom-defined test groups that are not automatically generated. These groups often contain complex workflow logic or specific scenarios that require manual test definition. It's often structured by IG version (e.g., `v2.0.1/`).
+    *   Files like `pas_client_approval_group.rb`, `pas_server_subscription_setup.rb` define specific sequences of tests.
+*   **`igs/`**: Stores the IG package files (e.g., `davinci_pas_2.0.1.tgz`) that the generator uses as input.
+*   **`endpoints/`**: Contains code for managing the FHIR endpoints that Inferno exposes when acting as a server (e.g., for client testing). This might include endpoints for `$submit`, `$inquire`, and `Subscription` interactions.
+*   **`jobs/`**: For background jobs, if any. For PAS, this could include tasks like sending delayed subscription notifications (e.g., `send_pas_subscription_notification.rb`).
+*   **Supporting Logic Files**:
+    *   `fhir_resource_navigation.rb`: Utilities for navigating FHIR resources.
+    *   `must_support_test.rb`: Core logic for generating and running Must Support tests.
+    *   `pas_bundle_validation.rb`: Specific validation logic for PAS bundles.
+    *   `response_generator.rb`: Logic for Inferno to generate responses when acting as a server.
+    *   `validation_test.rb`: Core logic for FHIR validation tests.
+    *   `validator_suppressions.rb`: Configuration for suppressing known, non-critical validation errors.
+
+## Related Systems and Dependencies
+
+*   **Inferno Framework**: The foundational platform upon which this test kit is built. Knowledge of Inferno's architecture and development patterns is essential for significant contributions.
+*   **HL7 FHIR**: The core standard for data exchange.
+*   **Da Vinci PAS Implementation Guide**: The specific set of rules and profiles this test kit validates against.
+*   **FHIR Java Validator**: Used for validating resource conformance.
+*   **Terminology Server (`tx.fhir.org`)**: Used by the validator to resolve terminology and validate code bindings.
+*   **Ruby**: The programming language used for Inferno and this test kit.
+*   **RSpec**: The testing framework used for the test kit's own internal unit/integration tests (see `spec/` directory).
+
+## Testing Code Changes (Development Workflow)
+
+When making changes to the test kit itself, it's important to ensure the changes are correct and do not introduce regressions.
+
+1.  **Understand the Scope**: Determine if your change affects generated tests, custom test groups, core logic, or documentation.
+2.  **Make Code Changes**: Implement your fixes or new features.
+3.  **Run RSpec Tests**:
+    *   The test kit has its own suite of tests located in the `spec/` directory. These are RSpec tests that validate the test kit's internal logic, generators, etc.
+    *   From the root directory of the test kit, you can typically run these tests using a command like `bundle exec rspec`.
+    *   Ensure all RSpec tests pass before considering your changes complete.
+4.  **Manual Testing (Using Inferno UI)**:
+    *   Run your local Inferno instance (`run.sh` after `setup.sh`), or use the [developer-oriented method](https://inferno-framework.github.io/docs/getting-started/#development-with-ruby).
+    *   Manually execute the test suites/groups affected by your changes against:
+        *   The public reference implementations (if applicable).
+        *   Any local test servers or client simulators you have.
+        *   The provided Postman collection for client tests.
+    *   This helps catch issues that RSpec tests might miss, especially those related to UI interactions or workflow logic as experienced by a user.
+5.  **Test Generation (If Applicable)**:
+    *   If you've modified the test generator (`lib/davinci_pas_test_kit/generator/`), you'll need to re-generate the affected tests:
+        *   Ensure the relevant IG package is in `lib/davinci_pas_test_kit/igs/`.
+        *   Run `bundle exec rake pas:generate`.
+        *   Review the generated files for correctness.
+        *   Run the re-generated tests in the Inferno UI.
+6.  **Update Documentation**: If your changes affect user-facing behavior, test procedures, or technical details, update the relevant documentation files in `/docs/`. These will be automatically mirrored to the repository's [GitHub Wiki](https://github.com/inferno-framework/davinci-pas-test-kit/wiki).
+
+
+## Contribution Guidelines
+
+*   **Follow Existing Patterns**: Try to adhere to the coding style and architectural patterns already present in the test kit and the Inferno Framework.
+*   **Write RSpec Tests**: For new logic or significant changes, add corresponding RSpec tests.
+*   **Keep Documentation Updated**: Ensure your contributions are reflected in the documentation.
+*   **Report Issues**: Use the [GitHub Issues page](https://github.com/inferno-framework/davinci-pas-test-kit/issues) for the repository to report bugs or suggest enhancements.
+*   **Pull Requests**: Submit changes via pull requests for review.
+*   **Update Documentation**: Please be sure to update all suite descriptions, test descriptions, the README, and the contents of the `./docs` folder of this repository along with code changes.
+
+## Unusual Implementation Details
+
+*   **X12 Dependency**: The PAS IG's reliance on proprietary X12 information for some terminology and semantics is a significant challenge. The test kit cannot directly validate these aspects and often relies on attestation or flags them as limitations.
+*   **Test Data Input**: For server testing, the kit relies heavily on users providing their own conformant request bundles that are designed to elicit specific responses (approval, denial, etc.) from their server. This is because the exact business logic for these decisions is outside the scope of the FHIR IG.

--- a/docs/Test-Generation-Guide.md
+++ b/docs/Test-Generation-Guide.md
@@ -1,12 +1,24 @@
 # Da Vinci PAS Test Kit: Test Generation Guide
 
-This document provides a comprehensive guide on how tests are generated for the Da Vinci Prior Authorization Support (PAS) Test Kit, how to use the generator, and some insights into its mechanics for maintainers.
+This document provides a comprehensive guide on how tests are generated for the
+Da Vinci Prior Authorization Support (PAS) Test Kit, how to use the generator,
+and some insights into its mechanics for maintainers.
 
 ## Overview
 
-A significant portion of the tests within the Da Vinci PAS Test Kit, particularly those related to profile validation and must-support element checks, are programmatically generated. This approach ensures that the test kit remains aligned with the specific version of the PAS Implementation Guide (IG) it targets and reduces the manual effort required to update tests when new IG versions are released or when profiles change.
+A portion of the server tests within the Da Vinci PAS Test Kit, particularly
+those related to profile validation and must-support element checks, are
+programmatically generated. This approach ensures that the test kit remains
+aligned with the specific version of the PAS Implementation Guide (IG) it
+targets and reduces the manual effort required to update tests when new IG
+versions are released or when profiles change.
 
 The test generator processes the formal artifacts of the PAS IG (such as StructureDefinitions and CapabilityStatements) to create executable test code.
+
+Note that any time you make changes to content in the
+`lib/davinci_pas/generator` directory, you will need to regenerate the tests. 
+Do not make changes to the `generated` directory directly, because these will be
+overwritten during the next generation.
 
 ## Prerequisites for Test Generation
 
@@ -47,7 +59,7 @@ Follow these steps to generate a new test suite or update an existing one for a 
     *   In the Inferno UI, you should now see the newly generated (or updated) test suite available for selection.
     *   Execute some of the generated tests to ensure they load correctly and behave as expected. Test against a reference implementation or sample data if possible.
 
-## Generator Mechanics (For Maintainers)
+## Generator Mechanics
 
 The test generation logic resides primarily in the `lib/davinci_pas_test_kit/generator/` directory. Key components include:
 
@@ -71,4 +83,6 @@ The general process is:
 5.  These tests are organized into groups, and the groups form a test suite.
 6.  The generated Ruby files are written to the `lib/davinci_pas_test_kit/generated/<ig_version>/` directory.
 
-Maintaining or extending the generator requires a good understanding of Ruby, the Inferno Framework's testing DSL (Domain Specific Language), and the structure of FHIR Implementation Guide packages.
+Maintaining or extending the generator requires a good understanding of Ruby,
+the Inferno Framework's testing DSL (Domain Specific Language), and the
+structure of FHIR Implementation Guide packages.

--- a/docs/Test-Generation-Guide.md
+++ b/docs/Test-Generation-Guide.md
@@ -1,0 +1,74 @@
+# Da Vinci PAS Test Kit: Test Generation Guide
+
+This document provides a comprehensive guide on how tests are generated for the Da Vinci Prior Authorization Support (PAS) Test Kit, how to use the generator, and some insights into its mechanics for maintainers.
+
+## Overview
+
+A significant portion of the tests within the Da Vinci PAS Test Kit, particularly those related to profile validation and must-support element checks, are programmatically generated. This approach ensures that the test kit remains aligned with the specific version of the PAS Implementation Guide (IG) it targets and reduces the manual effort required to update tests when new IG versions are released or when profiles change.
+
+The test generator processes the formal artifacts of the PAS IG (such as StructureDefinitions and CapabilityStatements) to create executable test code.
+
+## Prerequisites for Test Generation
+
+Before you can generate tests, ensure you have the following set up:
+
+1.  **Ruby Environment**: The test kit and its generator are written in Ruby. You'll need a working Ruby installation.
+2.  **Bundler**: The project uses Bundler to manage Ruby gems (dependencies). Install it with `gem install bundler`.
+3.  **Project Dependencies**: From the root directory of the `davinci-pas-test-kit`, run `bundle install` to install all required gems.
+4.  **PAS IG Package**: You need the `.tgz` package file for the specific version of the Da Vinci PAS IG you want to generate tests for. This package contains the machine-readable artifacts (profiles, extensions, value sets, etc.).
+
+## How to Generate Tests for an IG Version
+
+Follow these steps to generate a new test suite or update an existing one for a specific PAS IG version:
+
+1.  **Obtain the IG Package**:
+    *   Download the `package.tgz` (or similarly named `.tgz` file) for the desired Da Vinci PAS IG version. This is typically available from the HL7 FHIR IG registry or the IG's publication page.
+
+2.  **Place the IG Package**:
+    *   Navigate to the `lib/davinci_pas_test_kit/igs/` directory within your local clone of the `davinci-pas-test-kit` repository.
+    *   Place the downloaded `.tgz` file into this `igs/` directory.
+    *   It's good practice to rename the file to clearly indicate the IG version, for example, `davinci_pas_2.0.1.tgz` or `davinci_pas_2.1.0.tgz`. The generator might infer the version from the filename or internal package metadata.
+
+3.  **Run the Generator Task**:
+    *   Open your terminal and navigate to the root directory of the `davinci-pas-test-kit`.
+    *   Execute the Rake task for PAS test generation:
+        ```bash
+        bundle exec rake pas:generate
+        ```
+    *   This command will invoke the scripts located in `lib/davinci_pas_test_kit/generator/`.
+
+4.  **Verify Generated Files**:
+    *   After the generator runs, check the `lib/davinci_pas_test_kit/generated/` directory. You should see a new subdirectory corresponding to the IG version you targeted (e.g., `v2.0.1/`).
+    *   Inside this version-specific directory, you'll find generated Ruby files containing test groups, profile validation tests, must-support tests, and other necessary components.
+    *   Also, check `lib/davinci_pas_test_kit/metadata.rb` to ensure the new suite ID (if a new version was added) is registered.
+
+5.  **Test the Generated Suite**:
+    *   Run your local Inferno instance (`./run.sh` after `./setup.sh`).
+    *   In the Inferno UI, you should now see the newly generated (or updated) test suite available for selection.
+    *   Execute some of the generated tests to ensure they load correctly and behave as expected. Test against a reference implementation or sample data if possible.
+
+## Generator Mechanics (For Maintainers)
+
+The test generation logic resides primarily in the `lib/davinci_pas_test_kit/generator/` directory. Key components include:
+
+*   **`ig_loader.rb`**: Responsible for loading and parsing the IG package (`.tgz` file), making its resources (StructureDefinitions, CapabilityStatements, etc.) accessible.
+*   **`ig_metadata_extractor.rb` / `ig_metadata.rb`**: Extracts high-level metadata from the IG.
+*   **`suite_generator.rb`**: Orchestrates the generation of an entire test suite for an IG version.
+*   **`group_generator.rb` / `group_metadata.rb`**: Handles the creation of test groups within the suite.
+*   **`must_support_test_generator.rb`**: Specifically generates tests for "must support" elements defined in profiles. It inspects StructureDefinitions to identify these elements and creates tests to verify their presence or handling.
+*   **`validation_test_generator.rb`**: Generates tests that perform FHIR profile validation on resources.
+*   **`naming.rb`**: Provides conventions for naming generated files, classes, and test IDs.
+*   **Templates**: The generator likely uses ERB (Embedded Ruby) templates (often found within the `generator/templates/` subdirectory, though not explicitly listed in the initial file view) to structure the generated Ruby code for tests and groups.
+
+The general process is:
+1.  The Rake task invokes the main generator script.
+2.  The IG package is loaded.
+3.  Relevant resources (profiles, capability statements) are identified.
+4.  For each profile, tests are generated for:
+    *   Basic resource validation against the profile.
+    *   Validation of "must support" elements.
+    *   Potentially tests for specific operations or interactions defined in CapabilityStatements.
+5.  These tests are organized into groups, and the groups form a test suite.
+6.  The generated Ruby files are written to the `lib/davinci_pas_test_kit/generated/<ig_version>/` directory.
+
+Maintaining or extending the generator requires a good understanding of Ruby, the Inferno Framework's testing DSL (Domain Specific Language), and the structure of FHIR Implementation Guide packages.

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,0 +1,5 @@
+_Test kit documentation is stored within the [./docs](../tree/main/docs) folder of
+this repository and is automatically synchronized to this wiki with each update
+to the `main` branch using the [Publish Docs Wiki
+workflow](../actions/workflows/publish-docs-wiki.yml).  Do not change content
+within this wiki directly as changes will be overwritten._

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,23 @@
+**[Documentation Home](Home)**
+
+**Using this Test Kit**
+*   [Getting Started](https://github.com/inferno-framework/davinci-pas-test-kit/?tab=readme-ov-file#getting-started)
+*   [Test Kit Overview](Overview)
+
+**Client Suite**
+*   [Client Testing Details](Client-Details)
+*   [Client Testing Walkthrough](Client-Walkthrough)
+
+**Server Suite**
+*   [Server Testing Details](Server-Details)
+*   [Server Testing Walkthrough](Server-Walkthrough)
+
+**Contributing to this Test Kit**
+*   [Technical Overview](Technical-Overview)
+*   [Test Generation Guide](Test-Generation-Guide)
+
+**Reference Documents & External Links**
+*   [PAS Requirements Interpretation (Spreadsheet)](../tree/main/lib/davinci_pas_test_kit/docs/PAS-Requirements-Interpretation.xlsx)
+*   [Da Vinci PAS IG (STU2)](https://hl7.org/fhir/us/davinci-pas/STU2/)
+*   [Inferno Framework](https://inferno-framework.github.io/)
+*   [Report an Issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues)

--- a/lib/davinci_pas_test_kit/client_suite.rb
+++ b/lib/davinci_pas_test_kit/client_suite.rb
@@ -22,7 +22,44 @@ module DaVinciPASTestKit
     class ClientSuite < Inferno::TestSuite
       id :davinci_pas_client_suite_v201
       title 'Da Vinci PAS Client Suite v2.0.1'
-      description File.read(File.join(__dir__, 'docs', 'client_suite_description_v201.md'))
+      description %(
+        The Da Vinci PAS Test Kit Client Suite validates the conformance of client
+        systems to the STU 2 version of the HL7® FHIR®
+        [Da Vinci Prior Authorization Support Implementation Guide](https://hl7.org/fhir/us/davinci-pas/STU2/).
+
+        These tests are a **DRAFT** intended to allow PAS client implementers to perform
+        preliminary checks of their clients against PAS IG requirements and [provide
+        feedback](https://github.com/inferno-framework/davinci-pas-test-kit/issues)
+        on the tests. Future versions of these tests may validate other
+        requirements and may change the test validation logic.
+
+        The best place to get started is the [Client Testing
+        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Walkthrough)],
+        which provides a step-by-step guide for running the tests against a client and provides
+        an example client implemented in Postman.  Visit the [Client Testing
+        Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Details)
+        documentation for information about technical implementation and known limitations of these tests.
+
+        In this test suite, Inferno simulates a PAS server for the client under test to
+        interact with. The client will be expected to initiate requests to the server
+        and demonstrate its ability to react to the returned responses. Over the course
+        of these interactions, Inferno will seek to observe conformant handling of PAS
+        requirements, including:
+        - The ability of the client to initiate a prior authorization submission and react to
+            - The approval of the request
+            - The denial of the request
+            - The pending of the request and a subsequent notification that a final decision was made
+        - The ability of the client to provide data covering the full scope of required by PAS, including
+            - The ability to send prior auth requests and inquiries with all PAS
+              profiles and all must support elements on those profiles
+            - The ability to handle responses that contain all PAS profiles and all must support elements on those
+              profiles (not included in the current version of these tests)
+
+        All requests and responses will be checked for conformance to the PAS
+        IG requirements individually and used in aggregate to determine whether
+        required features and functionality are present. HL7® FHIR® resources are
+        validated with the Java validator using `tx.fhir.org` as the terminology server.
+      )
 
       links [
         {

--- a/lib/davinci_pas_test_kit/client_suite.rb
+++ b/lib/davinci_pas_test_kit/client_suite.rb
@@ -34,7 +34,7 @@ module DaVinciPASTestKit
         requirements and may change the test validation logic.
 
         The best place to get started is the [Client Testing
-        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Walkthrough)],
+        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Walkthrough),
         which provides a step-by-step guide for running the tests against a client and provides
         an example client implemented in Postman.  Visit the [Client Testing
         Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Details)

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/server_suite.rb
@@ -23,7 +23,7 @@ module DaVinciPASTestKit
         requirements and may change the test validation logic.
 
         The best place to get started is the [Server Testing
-        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough)],
+        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough),
         which provides a step-by-step guide for running the tests against a client and provides
         an example client implemented in Postman.  Visit the [Server Testing
         Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)

--- a/lib/davinci_pas_test_kit/generated/v2.0.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/generated/v2.0.1/server_suite.rb
@@ -11,7 +11,46 @@ module DaVinciPASTestKit
     class ServerSuite < Inferno::TestSuite
       id :davinci_pas_server_suite_v201
       title 'Da Vinci PAS Server Suite v2.0.1'
-      description File.read(File.join(__dir__, '..', '..', 'docs', 'server_suite_description_v201.md'))
+      description %(
+        The Da Vinci PAS Server Suite validates the conformance of server systems 
+        to the STU 2 version of the HL7® FHIR® 
+        [Da Vinci Prior Authorization Support Implementation Guide](https://hl7.org/fhir/us/davinci-pas/STU2/).
+
+        These tests are a **DRAFT** intended to allow PAS server implementers to perform 
+        preliminary checks of their servers against PAS IG requirements and [provide 
+        feedback](https://github.com/inferno-framework/davinci-pas-test-kit/issues) 
+        on the tests. Future versions of these tests may validate other 
+        requirements and may change the test validation logic.
+
+        The best place to get started is the [Server Testing
+        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough)],
+        which provides a step-by-step guide for running the tests against a client and provides
+        an example client implemented in Postman.  Visit the [Server Testing
+        Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)
+        documentation for information about technical implementation and known limitations of these tests.
+
+        Inferno will simulate a client and make a series of prior authorization requests to the 
+        server under test. Over the course of these requests, Inferno will seek to observe
+        conformant handling of PAS requirements, including
+        - The ability of the server to use PAS API interactions to communicate 
+            - Approval of a prior authorization request
+            - Denial of a prior authorization request
+            - Pending of a prior authorization request and a subsequent final decision
+            - Inability to process a prior authorization request
+        - The ability of the server to handle the full scope of data required by PAS, including
+            - Ability to process prior auth requests and inquiries with all PAS profiles and all must support elements on those profiles
+            - Ability to return responses that demonstrate the use of all PAS profiles and all must support elements on those profiles
+
+        Because the business logic that determines decisions and the elements populated in responses
+        Is outside of the PAS specification and will vary between implementers, testers
+        are required to provide the requests that Inferno will make to the server.
+
+        All requests and responses will be checked for conformance to the PAS
+        IG requirements individually and used in aggregate to determine whether
+        required features and functionality are present. HL7® FHIR® resources are 
+        validated with the Java validator using `tx.fhir.org` as the terminology server.
+      
+      %)
 
       links [
         {

--- a/lib/davinci_pas_test_kit/generator/templates/suite.rb.erb
+++ b/lib/davinci_pas_test_kit/generator/templates/suite.rb.erb
@@ -20,7 +20,7 @@ module DaVinciPASTestKit
         requirements and may change the test validation logic.
 
         The best place to get started is the [Server Testing
-        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough)],
+        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough),
         which provides a step-by-step guide for running the tests against a client and provides
         an example client implemented in Postman.  Visit the [Server Testing
         Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)

--- a/lib/davinci_pas_test_kit/generator/templates/suite.rb.erb
+++ b/lib/davinci_pas_test_kit/generator/templates/suite.rb.erb
@@ -8,7 +8,46 @@ module DaVinciPASTestKit
     class <%= class_name %> < Inferno::TestSuite
       id :<%= suite_id %>
       title '<%= title %>'
-      description File.read(File.join(__dir__, '..', '..', 'docs', 'server_suite_description_<%= ig_metadata.reformatted_version %>.md'))
+      description %(
+        The Da Vinci PAS Server Suite validates the conformance of server systems 
+        to the STU 2 version of the HL7® FHIR® 
+        [Da Vinci Prior Authorization Support Implementation Guide](https://hl7.org/fhir/us/davinci-pas/STU2/).
+
+        These tests are a **DRAFT** intended to allow PAS server implementers to perform 
+        preliminary checks of their servers against PAS IG requirements and [provide 
+        feedback](https://github.com/inferno-framework/davinci-pas-test-kit/issues) 
+        on the tests. Future versions of these tests may validate other 
+        requirements and may change the test validation logic.
+
+        The best place to get started is the [Server Testing
+        Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Walkthrough)],
+        which provides a step-by-step guide for running the tests against a client and provides
+        an example client implemented in Postman.  Visit the [Server Testing
+        Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)
+        documentation for information about technical implementation and known limitations of these tests.
+
+        Inferno will simulate a client and make a series of prior authorization requests to the 
+        server under test. Over the course of these requests, Inferno will seek to observe
+        conformant handling of PAS requirements, including
+        - The ability of the server to use PAS API interactions to communicate 
+            - Approval of a prior authorization request
+            - Denial of a prior authorization request
+            - Pending of a prior authorization request and a subsequent final decision
+            - Inability to process a prior authorization request
+        - The ability of the server to handle the full scope of data required by PAS, including
+            - Ability to process prior auth requests and inquiries with all PAS profiles and all must support elements on those profiles
+            - Ability to return responses that demonstrate the use of all PAS profiles and all must support elements on those profiles
+
+        Because the business logic that determines decisions and the elements populated in responses
+        Is outside of the PAS specification and will vary between implementers, testers
+        are required to provide the requests that Inferno will make to the server.
+
+        All requests and responses will be checked for conformance to the PAS
+        IG requirements individually and used in aggregate to determine whether
+        required features and functionality are present. HL7® FHIR® resources are 
+        validated with the Java validator using `tx.fhir.org` as the terminology server.
+      
+      %)
 
       links [
         {

--- a/lib/davinci_pas_test_kit/metadata.rb
+++ b/lib/davinci_pas_test_kit/metadata.rb
@@ -12,6 +12,10 @@ module DaVinciPASTestKit
 
       <!-- break -->
 
+      Please visit the [Da Vinci PAS Test Kit documentation
+      site](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/) for
+      detailed information on how to use and maintain this test kit.
+
       To validate the behavior of a system Inferno will act as the partner to the
       system under test:
       - **When testing a client**: Inferno will act as a server, awaiting requests
@@ -58,21 +62,12 @@ module DaVinciPASTestKit
         e.g., the requirement that clinicians can update details of the prior authorization
         request before submitting them
 
-      For additional details on these and other areas where the tests may not align with
-      the IGs requirements, see our detailed documentation:
-      - [Test Kit Overview](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Overview#test-scope-and-limitations)
-      - [Client Suite Description](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md#testing-limitations)
-      - [Server Suite Description](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md#testing-limitations)
-      - [PAS Requirements Interpretation Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx)
-
-      The [main documentation site](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/) can be found on our GitHub Wiki.
-
       ### Known IG Issues
 
       Through testing with this test kit, issues have been identified in the version of the PAS
       specification that this test kit tests against which cause false failures. The full list
       of known issues can be found on the [repository's issues page with the 'source ig issue'
-      lable](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).
+      label](https://github.com/inferno-framework/davinci-pas-test-kit/labels/source%20ig%20issue).
 
       ## Reporting Issues
 

--- a/lib/davinci_pas_test_kit/metadata.rb
+++ b/lib/davinci_pas_test_kit/metadata.rb
@@ -59,8 +59,13 @@ module DaVinciPASTestKit
         request before submitting them
 
       For additional details on these and other areas where the tests may not align with
-      the IGs requirements, see documentation in the test kit source code ([client](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md#testing-limitations), [server](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md#testing-limitations)), and [this requirements analysis
-      spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx).
+      the IGs requirements, see our detailed documentation:
+      - [Test Kit Overview](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Overview#test-scope-and-limitations)
+      - [Client Suite Description](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/client_suite_description_v201.md#testing-limitations)
+      - [Server Suite Description](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/server_suite_description_v201.md#testing-limitations)
+      - [PAS Requirements Interpretation Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx)
+
+      The [main documentation site](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/) can be found on our GitHub Wiki.
 
       ### Known IG Issues
 


### PR DESCRIPTION
# Summary

This PR overhauls the Da Vinci PAS Test Kit's documentation by migrating detailed content from in-code descriptions and the main README into a structured set of Markdown files within a new `docs/` directory. This new structure is published as the project's [GitHub Wiki (preview available)](/inferno-framework/davinci-pas-test-kit/wiki), providing a more accessible and user-friendly documentation experience.

**Key Changes:**

*   **New `docs/` Directory:** Introduced a `docs/` directory containing granular Markdown files for:
    *   Overall Test Kit Overview
    *   Client & Server Testing Walkthroughs (step-by-step guides)
    *   Client & Server Suite Implementation Details
    *   Technical Overview (for developers/contributors)
    *   Server Test Generation Guide
    *   Wiki navigation files (`_Sidebar.md`, `_Footer.md`)
*   **Updated README.md:** The main project `README.md` has been streamlined to provide essential getting started information and now prominently links to the new GitHub Wiki for comprehensive documentation. Sections like detailed scope, limitations, and development guides have been moved to the wiki.
*   **Revised In-Code Suite Descriptions:**
    *   The lengthy Markdown descriptions embedded within `client_suite.rb`, `server_suite.rb`, and the suite generator template (`suite.rb.erb`) have been significantly condensed.
    *   These descriptions now provide a brief overview and direct users to the relevant pages on the GitHub Wiki for detailed information (e.g., Walkthroughs, Technical Details).
*   **Updated `metadata.rb`:** The test kit's main description in `metadata.rb` (often displayed on the Inferno landing page) has been updated to reflect the new documentation structure and link to the wiki.
*   **Content Migration:** Existing documentation content previously found in `lib/davinci_pas_test_kit/docs/client_suite_description_v201.md` and `server_suite_description_v201.md` has been refactored and moved into the new `docs/Client-Details.md` and `docs/Server-Details.md` respectively, with procedural/walkthrough content extracted into new dedicated files.

## Testing

Load up the suites and see if it makes sense from a new user perspective documentation makes sense.  Note I copy/pasted content from the suite descriptions where they were mostly relevant, so that should still be accurate.  I worry a little bit that distributing the content around to a few spots might actually be worse, but I'm not sure.

Also, note that I do link to the 'README' for 'Getting Started', which is a new section so that link won't quite work until/if this pr is merged.
