### PR TITLE
Add publish workflow.

### DIFF
--- a/.github/workflows/publish-docs-wiki.yml
+++ b/.github/workflows/publish-docs-wiki.yml
@@ -1,0 +1,21 @@
+name: Publish Docs Wiki
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/**
+  workflow_dispatch:
+concurrency:
+  group: publish-docs-wiki
+  cancel-in-progress: true
+permissions:
+  contents: write
+jobs:
+  publish-docs-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Andrew-Chen-Wang/github-wiki-action@86138cbd6328b21d759e89ab6e6dd6a139b22270
+        with:
+          path: docs
+          strategy: init


### PR DESCRIPTION
# Summary

Adding wiki publish workflow, which will aid in previewing the updates to the documentation site over on #41 

This is just a direct copy from us core, so i do not think it is necessary to test anything.

