### PR TITLE
Fix requirements spreadsheet link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ preliminary checks of their implementations against PAS IG requirements and prov
 feedback on the tests. Future versions of these tests may validate other 
 requirements and may change how these are tested.
 
-Additional details on the IG requirements that underlie this test kit, including
-those that are not currently tested, can be found in [this
-spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/raw/refs/heads/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx).
+Additional details on the IG requirements that underlie this test kit can be found in the [Inferno Requirements Tools](https://inferno-framework.github.io/docs/advanced-test-features/requirements.html),
+including in [this spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/requirements/hl7.fhir.us.davinci-pas_2.0.1_requirements.xlsx).
 The spreadsheet includes:
 
 - a list of requirements extracted from the IG.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -59,8 +59,8 @@ issues, please consult the following resources: the [Client Testing
 Limitations](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Details#testing-limitations),
 the [Server Testing
 Limitations](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details#testing-limitations),
-the [PAS Requirements Interpretation
-Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/tree/main/lib/davinci_pas_test_kit/docs/PAS%20Requirements%20Interpretation.xlsx),
+the [PAS Requirements Spreadsheet
+Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/requirements/hl7.fhir.us.davinci-pas_2.0.1_requirements.xlsx),
 and the project's [GitHub Issues
 page](https://github.com/inferno-framework/davinci-pas-test-kit/issues).
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -59,8 +59,7 @@ issues, please consult the following resources: the [Client Testing
 Limitations](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Details#testing-limitations),
 the [Server Testing
 Limitations](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details#testing-limitations),
-the [PAS Requirements Spreadsheet
-Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/requirements/hl7.fhir.us.davinci-pas_2.0.1_requirements.xlsx),
+the [PAS Requirements Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/requirements/hl7.fhir.us.davinci-pas_2.0.1_requirements.xlsx),
 and the project's [GitHub Issues
 page](https://github.com/inferno-framework/davinci-pas-test-kit/issues).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ provides information on how to use and contribute to this test kit.
 
 ## Reference Documents
 
-*   **[PAS Requirements Interpretation](../tree/main/lib/davinci_pas_test_kit/docs/PAS-Requirements-Interpretation.xlsx)**: Spreadsheet detailing the interpretation of IG requirements for this test kit.
+*   **[PAS Requirements Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/requirements/hl7.fhir.us.davinci-pas_2.0.1_requirements.xlsx)**: Spreadsheet detailing the interpretation of IG requirements for this test kit.
 
 ## Support
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -17,7 +17,7 @@
 *   [Test Generation Guide](Test-Generation-Guide)
 
 **Reference Documents & External Links**
-*   [PAS Requirements Interpretation (Spreadsheet)](../tree/main/lib/davinci_pas_test_kit/docs/PAS-Requirements-Interpretation.xlsx)
+*   [PAS Requirements Spreadsheet](https://github.com/inferno-framework/davinci-pas-test-kit/blob/main/lib/davinci_pas_test_kit/requirements/hl7.fhir.us.davinci-pas_2.0.1_requirements.xlsx)
 *   [Da Vinci PAS IG (STU2)](https://hl7.org/fhir/us/davinci-pas/STU2/)
 *   [Inferno Framework](https://inferno-framework.github.io/)
 *   [Report an Issue](https://github.com/inferno-framework/davinci-pas-test-kit/issues)


### PR DESCRIPTION
# Summary

Update links in the PAS documentation to point to the current requirements spreadsheet.

# Testing Guidance

Review the documentation and verify that all requirements spreadsheet links function.
