### PR TITLE
Add v2.2.0 Inquire response Parameters wrapping support

### DIFF
--- a/lib/davinci_pas_test_kit/client/endpoints/claim_endpoint.rb
+++ b/lib/davinci_pas_test_kit/client/endpoints/claim_endpoint.rb
@@ -67,7 +67,7 @@ module DaVinciPASTestKit
       user_inputted_response = UserInputResponse.user_inputted_response(test, operation, result)
       if user_inputted_response.present?
         generated_claim_response_uuid = nil
-        response_bundle_json = update_tester_provided_response(user_inputted_response, claim_full_url)
+        response_bundle_json = update_tester_provided_response(user_inputted_response, claim_full_url, ig_version)
       else
         decision = # always use the workflow, except for pended when the inquire will get approved
           if operation == 'inquire' && workflow == :pended
@@ -76,7 +76,8 @@ module DaVinciPASTestKit
             workflow
           end
         generated_claim_response_uuid = SecureRandom.uuid
-        response_bundle_json = mock_response_bundle(req_bundle, operation, decision, generated_claim_response_uuid)
+        response_bundle_json = mock_response_bundle(req_bundle, operation, decision, generated_claim_response_uuid,
+                                                    ig_version)
       end
 
       response.body = response_bundle_json
@@ -93,6 +94,11 @@ module DaVinciPASTestKit
       end
 
       results_repo.update_result(result.id, 'pass') unless test.config.options[:accepts_multiple_requests]
+    end
+
+    # Determines the IG version from the suite_id
+    def ig_version
+      @ig_version ||= suite_id.include?('v220') ? 'v2.2.0' : 'v2.0.1'
     end
 
     private

--- a/lib/davinci_pas_test_kit/client/response_generator.rb
+++ b/lib/davinci_pas_test_kit/client/response_generator.rb
@@ -35,16 +35,21 @@ module DaVinciPASTestKit
     # - reference to the submitted Claim (may not have control of created id). NOTE: this is likely
     #   incomplete - when the Claim is included, there are other things that
     #   need to be in the Bundle that may also not be controlled
-    def update_tester_provided_response(user_inputted_response, claim_full_url, _ig_version = 'v2.0.1')
+    def update_tester_provided_response(user_inputted_response, claim_full_url, ig_version = 'v2.0.1')
       response_resource = FHIR.from_contents(user_inputted_response)
       return user_inputted_response unless response_resource.present?
 
-      # For v2.2.0 inquire responses, extract Bundle(s) from Parameters
+      # For v2.2.0 inquire responses, wrap user's Bundle in Parameters if needed
+      if ig_version == 'v2.2.0' && response_resource.is_a?(FHIR::Bundle)
+        response_resource = wrap_bundle_in_parameters(response_resource)
+      end
+
+      # Extract Bundle(s) for updating
       bundles_to_update = []
       is_parameters = response_resource.resourceType == 'Parameters'
 
       if is_parameters
-        bundles_to_update = extract_bundles_from_parameters(response_resource)
+        bundles_to_update = extract_bundles_from_pas_inquiry_response_parameters(response_resource)
       elsif response_resource.is_a?(FHIR::Bundle)
         bundles_to_update = [response_resource]
       else
@@ -432,9 +437,5 @@ module DaVinciPASTestKit
       )
       parameters
     end
-
-    # Extracts Bundles from a Parameters resource
-    # @param parameters [FHIR::Parameters] The Parameters resource
-    # @return [Array<FHIR::Bundle>] Array of Bundles from return parameters
   end
 end

--- a/lib/davinci_pas_test_kit/client/response_generator.rb
+++ b/lib/davinci_pas_test_kit/client/response_generator.rb
@@ -1,5 +1,9 @@
+require_relative '../parameters_helper'
+
 module DaVinciPASTestKit
   module ResponseGenerator
+    include ParametersHelper
+
     def mock_id_only_notification_bundle(submit_response, subscription_reference, subscription_topic)
       notification_timestamp = Time.now.utc
       mock_notification_bundle = build_mock_notification_bundle(notification_timestamp, subscription_reference,
@@ -15,9 +19,15 @@ module DaVinciPASTestKit
       mock_notification_bundle.to_json
     end
 
-    def mock_response_bundle(request_bundle, operation, decision, claim_response_uuid = nil)
+    def mock_response_bundle(request_bundle, operation, decision, claim_response_uuid = nil, ig_version = 'v2.0.1')
       mocked_timestamp = Time.now.utc
-      build_mock_response_bundle(request_bundle, operation, decision, mocked_timestamp, claim_response_uuid)&.to_json
+      response = build_mock_response_bundle(request_bundle, operation, decision, mocked_timestamp, claim_response_uuid)
+      return nil unless response.present?
+
+      # For v2.2.0 inquire operations, wrap the Bundle in a Parameters resource
+      response = wrap_bundle_in_parameters(response) if ig_version == 'v2.2.0' && operation == 'inquire'
+
+      response.to_json
     end
 
     # update things that tester cannot get right themselves
@@ -25,20 +35,35 @@ module DaVinciPASTestKit
     # - reference to the submitted Claim (may not have control of created id). NOTE: this is likely
     #   incomplete - when the Claim is included, there are other things that
     #   need to be in the Bundle that may also not be controlled
-    def update_tester_provided_response(user_inputted_response, claim_full_url)
-      response_bundle = FHIR.from_contents(user_inputted_response)
-      return user_inputted_response unless response_bundle.present?
+    def update_tester_provided_response(user_inputted_response, claim_full_url, _ig_version = 'v2.0.1')
+      response_resource = FHIR.from_contents(user_inputted_response)
+      return user_inputted_response unless response_resource.present?
+
+      # For v2.2.0 inquire responses, extract Bundle(s) from Parameters
+      bundles_to_update = []
+      is_parameters = response_resource.resourceType == 'Parameters'
+
+      if is_parameters
+        bundles_to_update = extract_bundles_from_parameters(response_resource)
+      elsif response_resource.is_a?(FHIR::Bundle)
+        bundles_to_update = [response_resource]
+      else
+        return user_inputted_response
+      end
 
       now = Time.now.utc
-      response_bundle.timestamp = now.iso8601 if response_bundle&.timestamp.present?
-      claim_response_entry = response_bundle&.entry&.find { |e| e&.resource&.resourceType == 'ClaimResponse' }
-      if claim_response_entry.present?
+      bundles_to_update.each do |response_bundle|
+        response_bundle.timestamp = now.iso8601 if response_bundle&.timestamp.present?
+        claim_response_entry = response_bundle&.entry&.find { |e| e&.resource&.resourceType == 'ClaimResponse' }
+        next unless claim_response_entry.present?
+
         claim_response_entry.resource.created = now.iso8601 if claim_response_entry.resource.created
         if claim_response_entry.resource.request.present? && claim_full_url.present?
           claim_response_entry.resource.request.reference = claim_full_url
         end
       end
-      response_bundle.to_json
+
+      response_resource.to_json
     end
 
     # update things that tester cannot get right themselves
@@ -393,5 +418,23 @@ module DaVinciPASTestKit
       end
       "urn:uuid:#{SecureRandom.uuid}"
     end
+
+    # Wraps a Bundle in a Parameters resource for v2.2.0 inquire responses
+    # @param bundle [FHIR::Bundle] The Bundle to wrap
+    # @return [FHIR::Parameters] Parameters resource with the bundle as a return parameter
+    def wrap_bundle_in_parameters(bundle)
+      return nil unless bundle.is_a?(FHIR::Bundle)
+
+      parameters = FHIR::Parameters.new
+      parameters.parameter << FHIR::Parameters::Parameter.new(
+        name: 'return',
+        resource: bundle
+      )
+      parameters
+    end
+
+    # Extracts Bundles from a Parameters resource
+    # @param parameters [FHIR::Parameters] The Parameters resource
+    # @return [Array<FHIR::Bundle>] Array of Bundles from return parameters
   end
 end

--- a/lib/davinci_pas_test_kit/cross_suite/must_support/must_support_data_gathering.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/must_support/must_support_data_gathering.rb
@@ -1,7 +1,10 @@
+require_relative '../../parameters_helper'
 require_relative '../../generator/profile_metadata'
 
 module DaVinciPASTestKit
   module MustSupportDataGathering
+    include ParametersHelper
+
     def load_metadata_for_profile_version(profile_key, version)
       Generator::ProfileMetadata.new(
         YAML.load_file(File.join(__dir__, '..', 'generated', version, profile_key, 'metadata.yml'), aliases: true)
@@ -28,16 +31,29 @@ module DaVinciPASTestKit
 
       requests.each do |req|
         begin
-          bundle = FHIR.from_contents(type == 'request' ? req.request_body : req.response_body)
+          response_resource = FHIR.from_contents(type == 'request' ? req.request_body : req.response_body)
         rescue StandardError
           next
         end
 
-        next unless bundle.is_a?(FHIR::Bundle)
+        next unless response_resource.present?
 
-        resources << bundle
-        entry_resources = bundle.entry.map(&:resource)
-        resources.concat(entry_resources)
+        # Handle Parameters resource (v2.2.0 inquire responses)
+        if response_resource.resourceType == 'Parameters'
+          bundles = extract_bundles_from_parameters(response_resource)
+          bundles.each do |bundle|
+            next unless bundle.is_a?(FHIR::Bundle)
+
+            resources << bundle
+            entry_resources = bundle.entry.map(&:resource)
+            resources.concat(entry_resources)
+          end
+        elsif response_resource.is_a?(FHIR::Bundle)
+          # Handle Bundle resource (v2.0.1 or v2.2.0 non-inquire)
+          resources << response_resource
+          entry_resources = response_resource.entry.map(&:resource)
+          resources.concat(entry_resources)
+        end
       end
 
       resources

--- a/lib/davinci_pas_test_kit/cross_suite/must_support/must_support_data_gathering.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/must_support/must_support_data_gathering.rb
@@ -40,7 +40,7 @@ module DaVinciPASTestKit
 
         # Handle Parameters resource (v2.2.0 inquire responses)
         if response_resource.resourceType == 'Parameters'
-          bundles = extract_bundles_from_parameters(response_resource)
+          bundles = extract_bundles_from_pas_inquiry_response_parameters(response_resource)
           bundles.each do |bundle|
             next unless bundle.is_a?(FHIR::Bundle)
 

--- a/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require_relative '../parameters_helper'
 require_relative 'validation_test'
 require_relative 'pas_constants'
 
 module DaVinciPASTestKit
   module PasBundleValidation
     include DaVinciPASTestKit::ValidationTest
+    include ParametersHelper
 
     def validation_error_messages
       @validation_error_messages ||= []
@@ -33,14 +35,40 @@ module DaVinciPASTestKit
 
     def validate_pas_bundle_json(json, profile_url, version, request_type, bundle_type, skips: false, message: '')
       assert_valid_json(json)
-      bundle = FHIR.from_contents(json)
-      assert bundle.present?, 'Not a FHIR resource'
-      assert_resource_type(:bundle, resource: bundle)
+      resource = FHIR.from_contents(json)
+      assert resource.present?, 'Not a FHIR resource'
 
-      if bundle_type == 'request_bundle'
-        perform_request_validation(bundle, profile_url, version, request_type)
+      # For v2.2.0 inquire responses, expect Parameters resource
+      if version == '2.2.0' && request_type == 'inquire' && bundle_type == 'response_bundle'
+        unless resource.resourceType == 'Parameters'
+          error_msg = "Expected Parameters resource for v2.2.0 inquire response, but received #{resource.resourceType}"
+          assert false, error_msg
+        end
+
+        # Extract and validate each Bundle in the Parameters
+        bundles = extract_bundles_from_parameters(resource)
+        if bundles.empty?
+          error_msg = 'Parameters resource must contain at least one return parameter with a Bundle'
+          assert false, error_msg
+        end
+
+        bundles.each_with_index do |bundle, _index|
+          if bundle_type == 'request_bundle'
+            perform_request_validation(bundle, profile_url, version, request_type)
+          else
+            perform_response_validation(bundle, profile_url, version, request_type)
+          end
+        end
       else
-        perform_response_validation(bundle, profile_url, version, request_type)
+        # For v2.0.1 or non-inquire operations, expect Bundle resource
+        assert_resource_type(:bundle, resource: resource)
+        bundle = resource
+
+        if bundle_type == 'request_bundle'
+          perform_request_validation(bundle, profile_url, version, request_type)
+        else
+          perform_response_validation(bundle, profile_url, version, request_type)
+        end
       end
 
       validation_error_messages.each do |msg|

--- a/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
@@ -50,7 +50,7 @@ module DaVinciPASTestKit
         elsif resource.is_a?(FHIR::Bundle)
           # Bundle received instead of Parameters - validate it but log an error
           validation_error_messages << 'Expected Parameters resource for v2.2.0 inquire response, but received ' \
-                                       "#{resource.resourceType}. The response Bundle should be wrapped in a " \
+                                       'Bundle. The response Bundle should be wrapped in a ' \
                                        'Parameters resource with a return parameter.'
           perform_response_validation(resource, profile_url, version, request_type)
         else

--- a/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
@@ -40,24 +40,22 @@ module DaVinciPASTestKit
 
       # For v2.2.0 inquire responses, expect Parameters resource
       if version == '2.2.0' && request_type == 'inquire' && bundle_type == 'response_bundle'
-        unless resource.resourceType == 'Parameters'
-          error_msg = "Expected Parameters resource for v2.2.0 inquire response, but received #{resource.resourceType}"
-          assert false, error_msg
-        end
+        if resource.resourceType == 'Parameters'
+          # Extract and validate each Bundle in the Parameters
+          bundles = extract_bundles_from_pas_inquiry_response_parameters(resource)
 
-        # Extract and validate each Bundle in the Parameters
-        bundles = extract_bundles_from_parameters(resource)
-        if bundles.empty?
-          error_msg = 'Parameters resource must contain at least one return parameter with a Bundle'
-          assert false, error_msg
-        end
-
-        bundles.each_with_index do |bundle, _index|
-          if bundle_type == 'request_bundle'
-            perform_request_validation(bundle, profile_url, version, request_type)
-          else
+          bundles.each do |bundle|
             perform_response_validation(bundle, profile_url, version, request_type)
           end
+        elsif resource.is_a?(FHIR::Bundle)
+          # Bundle received instead of Parameters - validate it but log an error
+          validation_error_messages << 'Expected Parameters resource for v2.2.0 inquire response, but received ' \
+                                       "#{resource.resourceType}. The response Bundle should be wrapped in a " \
+                                       'Parameters resource with a return parameter.'
+          perform_response_validation(resource, profile_url, version, request_type)
+        else
+          assert false,
+                 "Expected Parameters resource for v2.2.0 inquire response, but received #{resource.resourceType}"
         end
       else
         # For v2.0.1 or non-inquire operations, expect Bundle resource

--- a/lib/davinci_pas_test_kit/parameters_helper.rb
+++ b/lib/davinci_pas_test_kit/parameters_helper.rb
@@ -2,10 +2,10 @@ module DaVinciPASTestKit
   # Helper module for working with FHIR Parameters resources in v2.2.0
   # Provides utilities to extract Bundles from Parameters.parameter entries
   module ParametersHelper
-    # Extracts Bundles from a Parameters resource
+    # Extracts Bundles from a PAS Inquiry Response Parameters resource
     # @param parameters [FHIR::Parameters] The Parameters resource
     # @return [Array<FHIR::Bundle>] Array of Bundles from return parameters
-    def extract_bundles_from_parameters(parameters)
+    def extract_bundles_from_pas_inquiry_response_parameters(parameters)
       return [] unless parameters.is_a?(FHIR::Parameters)
 
       parameters.parameter

--- a/lib/davinci_pas_test_kit/parameters_helper.rb
+++ b/lib/davinci_pas_test_kit/parameters_helper.rb
@@ -1,0 +1,18 @@
+module DaVinciPASTestKit
+  # Helper module for working with FHIR Parameters resources in v2.2.0
+  # Provides utilities to extract Bundles from Parameters.parameter entries
+  module ParametersHelper
+    # Extracts Bundles from a Parameters resource
+    # @param parameters [FHIR::Parameters] The Parameters resource
+    # @return [Array<FHIR::Bundle>] Array of Bundles from return parameters
+    def extract_bundles_from_parameters(parameters)
+      return [] unless parameters.is_a?(FHIR::Parameters)
+
+      parameters.parameter
+        .select { |param| param.name == 'return' }
+        .map(&:resource)
+        .compact
+        .select { |resource| resource.is_a?(FHIR::Bundle) }
+    end
+  end
+end

--- a/lib/davinci_pas_test_kit/server/claim_operation_logic.rb
+++ b/lib/davinci_pas_test_kit/server/claim_operation_logic.rb
@@ -39,7 +39,13 @@ module DaVinciPASTestKit
     def check_response_status_and_payload(request)
       assert_response_status([200, 201])
       assert_valid_json(request.response_body, "Server response to $#{operation} was not json.")
-      assert_resource_type(:bundle, resource: FHIR.from_contents(request.response_body))
+      resource = FHIR.from_contents(request.response_body)
+      if config.options[:ig_version] == 'v2.2.0' && operation == 'inquire'
+        assert resource.resourceType == 'Parameters',
+               "Expected Parameters resource for v2.2.0 inquire response, but received #{resource.resourceType}"
+      else
+        assert_resource_type(:bundle, resource:)
+      end
     end
 
     def run_operation_test(request_payload)

--- a/lib/davinci_pas_test_kit/server/server_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/server/server_response_bundle_validation_test.rb
@@ -33,7 +33,7 @@ module DaVinciPASTestKit
         # Handle Parameters resource (v2.2.0 inquire responses)
         if resource.resourceType == 'Parameters'
           # Extract all Bundles from Parameters.parameter entries
-          parameter_bundles = extract_bundles_from_parameters(resource)
+          parameter_bundles = extract_bundles_from_pas_inquiry_response_parameters(resource)
           bundles.concat(parameter_bundles)
         elsif resource.is_a?(FHIR::Bundle)
           # Handle Bundle resource (v2.0.1 or v2.2.0 non-inquire)

--- a/lib/davinci_pas_test_kit/server/server_response_bundle_validation_test.rb
+++ b/lib/davinci_pas_test_kit/server/server_response_bundle_validation_test.rb
@@ -25,13 +25,25 @@ module DaVinciPASTestKit
     def response_bundles
       requests = load_tagged_requests(DaVinciPASTestKit.operation_tag(operation),
                                       DaVinciPASTestKit.use_case_tag(use_case))
-      fhir_resources =
-        requests.map(&:response_body).compact.uniq.map do |request_body|
-          FHIR.from_contents(request_body)
-        rescue StandardError
-          nil
-        end.compact
-      fhir_resources.select { |res| res.resourceType == 'Bundle' }
+      bundles = []
+      requests.map(&:response_body).compact.uniq.each do |response_body|
+        resource = FHIR.from_contents(response_body)
+        next unless resource.present?
+
+        # Handle Parameters resource (v2.2.0 inquire responses)
+        if resource.resourceType == 'Parameters'
+          # Extract all Bundles from Parameters.parameter entries
+          parameter_bundles = extract_bundles_from_parameters(resource)
+          bundles.concat(parameter_bundles)
+        elsif resource.is_a?(FHIR::Bundle)
+          # Handle Bundle resource (v2.0.1 or v2.2.0 non-inquire)
+          bundles << resource
+        end
+      rescue StandardError
+        next
+      end
+
+      bundles
     end
 
     run do

--- a/spec/davinci_pas_test_kit/client/response_generator_spec.rb
+++ b/spec/davinci_pas_test_kit/client/response_generator_spec.rb
@@ -116,12 +116,13 @@ RSpec.describe DaVinciPASTestKit::ResponseGenerator, :runnable do
         expect(claim_response.meta&.profile&.find { |profile| profile == claim_response_profile }).to_not be_nil
       end
 
-      it 'indicates claiminquiryresponse for $inquire responses' do
+      it 'indicates claiminquiryresponse for $inquire responses (v2.0.1 default)' do
         returned_response_string = module_instance.mock_response_bundle(
           FHIR.from_contents(submit_request_string),
           'inquire',
           :approval,
           nil
+          # No ig_version = defaults to v2.0.1
         )
 
         claim_response_profile = 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claiminquiryresponse'
@@ -130,6 +131,45 @@ RSpec.describe DaVinciPASTestKit::ResponseGenerator, :runnable do
         claim_response = returned_bundle.entry.find { |entry| entry.resource.is_a?(FHIR::ClaimResponse) }.resource
         expect(claim_response).to_not be_nil
         expect(claim_response.meta&.profile&.find { |profile| profile == claim_response_profile }).to_not be_nil
+      end
+
+      it 'returns Parameters resource for $inquire responses in v2.2.0' do
+        returned_response_string = module_instance.mock_response_bundle(
+          FHIR.from_contents(submit_request_string),
+          'inquire',
+          :approval,
+          nil,
+          'v2.2.0'
+        )
+
+        returned_resource = FHIR.from_contents(returned_response_string)
+        expect(returned_resource).to be_a(FHIR::Parameters)
+        expect(returned_resource.parameter.length).to be >= 1
+
+        # Extract the Bundle from Parameters
+        return_param = returned_resource.parameter.find { |p| p.name == 'return' }
+        expect(return_param).to_not be_nil
+        expect(return_param.resource).to be_a(FHIR::Bundle)
+
+        # Verify the Bundle inside has the correct profile
+        bundle = return_param.resource
+        claim_response = bundle.entry.find { |entry| entry.resource.is_a?(FHIR::ClaimResponse) }.resource
+        expect(claim_response).to_not be_nil
+        claim_response_profile = 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claiminquiryresponse'
+        expect(claim_response.meta&.profile&.find { |profile| profile == claim_response_profile }).to_not be_nil
+      end
+
+      it 'still returns Bundle for $submit operations in v2.2.0' do
+        returned_response_string = module_instance.mock_response_bundle(
+          FHIR.from_contents(submit_request_string),
+          'submit',
+          :approval,
+          nil,
+          'v2.2.0'
+        )
+
+        returned_bundle = FHIR.from_contents(returned_response_string)
+        expect(returned_bundle).to be_a(FHIR::Bundle)
       end
     end
 
@@ -467,6 +507,67 @@ RSpec.describe DaVinciPASTestKit::ResponseGenerator, :runnable do
       )
 
       expect(returned_response_string).to eq(non_fhir_json_string)
+    end
+
+    describe 'with v2.2.0 Parameters responses' do
+      let(:parameters_response_string) do
+        # Create a Parameters response with Bundle inside
+        parameters = FHIR::Parameters.new
+        bundle = FHIR.from_contents(submit_response_string)
+        parameters.parameter << FHIR::Parameters::Parameter.new(
+          name: 'return',
+          resource: bundle
+        )
+        parameters.to_json
+      end
+
+      it 'updates timestamps in Bundles within Parameters' do
+        time_now = Time.now
+        allow(Time).to receive(:now).and_return(time_now)
+
+        returned_response_string = module_instance.update_tester_provided_response(
+          parameters_response_string,
+          nil,
+          'v2.2.0'
+        )
+
+        parameters = FHIR.from_contents(returned_response_string)
+        expect(parameters).to be_a(FHIR::Parameters)
+
+        bundle = parameters.parameter.find { |p| p.name == 'return' }.resource
+        expect(bundle.timestamp).to eq(time_now.iso8601)
+
+        claim_response = bundle.entry.find { |entry| entry.resource.is_a?(FHIR::ClaimResponse) }.resource
+        expect(claim_response.created).to eq(time_now.iso8601)
+      end
+
+      it 'updates Claim references in Bundles within Parameters' do
+        parameters = FHIR::Parameters.new
+        bundle_with_claim = FHIR.from_contents(submit_response_string)
+        claim_response_with_claim = bundle_with_claim.entry.find do |entry|
+          entry.resource.is_a?(FHIR::ClaimResponse)
+        end.resource
+        old_claim_reference = "urn:uuid:#{SecureRandom.uuid}"
+        claim_response_with_claim.request = FHIR::Reference.new(
+          reference: old_claim_reference
+        )
+        parameters.parameter << FHIR::Parameters::Parameter.new(
+          name: 'return',
+          resource: bundle_with_claim
+        )
+
+        updated_claim_reference = "urn:uuid:#{SecureRandom.uuid}"
+        returned_response_string = module_instance.update_tester_provided_response(
+          parameters.to_json,
+          updated_claim_reference,
+          'v2.2.0'
+        )
+
+        returned_parameters = FHIR.from_contents(returned_response_string)
+        bundle = returned_parameters.parameter.find { |p| p.name == 'return' }.resource
+        claim_response = bundle.entry.find { |entry| entry.resource.is_a?(FHIR::ClaimResponse) }.resource
+        expect(claim_response.request.reference).to eq(updated_claim_reference)
+      end
     end
   end
 

--- a/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
@@ -226,22 +226,20 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
     end
 
     context 'when invalid response is provided for v2.2.0' do
-      it 'fails if Bundle provided instead of Parameters' do
+      it 'fails with error if Bundle provided instead of Parameters' do
         bundle_json = File.read(File.join(__dir__, '../..', 'fixtures', 'valid_pa_response_bundle.json'))
 
         result = run(test, server_endpoint:, response_json: bundle_json)
         expect(result.result).to eq('fail')
-        expect(result.result_message).to match(/Expected Parameters resource for v2.2.0 inquire response/)
+        expect(result.result_message).to match(/not conformant/)
       end
 
-      it 'fails if Parameters is empty (no return parameters)' do
+      it 'passes if Parameters is empty (no return parameters)' do
         parameters = FHIR::Parameters.new
-        # No parameters added - should fail
+        # No parameters added - valid per v2.2.0 (no matching results)
 
         result = run(test, server_endpoint:, response_json: parameters.to_json)
-        expect(result.result).to eq('fail')
-        expect(result.result_message)
-          .to match(/Parameters resource must contain at least one return parameter with a Bundle/)
+        expect(result.result).to eq('pass')
       end
     end
   end

--- a/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
@@ -161,4 +161,88 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
       end
     end
   end
+
+  describe '#validate_pas_bundle_json for v2.2.0' do
+    let(:test) do
+      Class.new(Inferno::Test) do
+        include DaVinciPASTestKit::PasBundleValidation
+
+        fhir_client { url :server_endpoint }
+        input :server_endpoint, :response_json
+
+        run do
+          profile_url = 'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-response-bundle'
+          validate_pas_bundle_json(
+            response_json,
+            profile_url,
+            '2.2.0',
+            'inquire',
+            'response_bundle'
+          )
+        end
+      end
+    end
+
+    before do
+      Inferno::Repositories::Tests.new.insert(test)
+      allow_any_instance_of(test).to receive(:validate_resources_conformance_against_profile).and_return(nil)
+    end
+
+    context 'when a valid Parameters response is provided' do
+      it 'validates the Parameters with Bundle inside' do
+        bundle_json = File.read(File.join(__dir__, '../..', 'fixtures', 'valid_pa_response_bundle.json'))
+        bundle = FHIR.from_contents(bundle_json)
+
+        # Wrap Bundle in Parameters
+        parameters = FHIR::Parameters.new
+        parameters.parameter << FHIR::Parameters::Parameter.new(
+          name: 'return',
+          resource: bundle
+        )
+
+        result = run(test, server_endpoint:, response_json: parameters.to_json)
+        expect(result.result).to eq('pass')
+      end
+
+      it 'validates Parameters with multiple Bundles (multiple return parameter entries)' do
+        bundle_json = File.read(File.join(__dir__, '../..', 'fixtures', 'valid_pa_response_bundle.json'))
+        bundle1 = FHIR.from_contents(bundle_json)
+        bundle2 = FHIR.from_contents(bundle_json)
+
+        # Create Parameters with multiple return parameter entries
+        parameters = FHIR::Parameters.new
+        parameters.parameter << FHIR::Parameters::Parameter.new(
+          name: 'return',
+          resource: bundle1
+        )
+        parameters.parameter << FHIR::Parameters::Parameter.new(
+          name: 'return',
+          resource: bundle2
+        )
+
+        result = run(test, server_endpoint:, response_json: parameters.to_json)
+        expect(result.result).to eq('pass')
+      end
+    end
+
+    context 'when invalid response is provided for v2.2.0' do
+      it 'fails if Bundle provided instead of Parameters' do
+        bundle_json = File.read(File.join(__dir__, '../..', 'fixtures', 'valid_pa_response_bundle.json'))
+
+        result = run(test, server_endpoint:, response_json: bundle_json)
+        expect(result.result).to eq('fail')
+        expect(result.result_message).to match(/Expected Parameters resource for v2.2.0 inquire response/)
+      end
+
+      it 'fails if Parameters is empty (no return parameters)' do
+        parameters = FHIR::Parameters.new
+        # No parameters added - should fail
+
+        result = run(test, server_endpoint:, response_json: parameters.to_json)
+        expect(result.result).to eq('fail')
+        expect(result.result_message)
+          .to match(/Parameters resource must contain at least one return parameter with a Bundle/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Implements support for the **v2.2.0 `$inquire` operation response format change** from a single `Bundle` to a `Parameters` resource containing 0 or more `return` parameter entries, each with a `Bundle` inside.

### Changes Made

#### Client Response Generation
- **response_generator.rb**: Added `wrap_bundle_in_parameters()` and `extract_bundles_from_parameters()` helpers
- **claim_endpoint.rb**: Added `ig_version` detection from `suite_id`

#### Validation Logic
- **pas_bundle_validation.rb**: Version-specific validation (strict for v2.2.0 - `$inquire` must return `Parameters`)
- **server_response_bundle_validation_test.rb**: Version-agnostic Bundle extraction

#### Must-Support Data Gathering
- **must_support_data_gathering.rb**: Parameters-aware resource extraction

#### Testing
- **response_generator_spec.rb**: Tests for wrapping/unwrapping logic
- **pas_bundle_validation_spec.rb**: Tests for single/multiple Bundles in Parameters

### Test Coverage
- Single Bundle wrapped in Parameters
- Multiple Bundles in Parameters (multiple `return` parameter entries)
- Error cases (Bundle instead of Parameters, empty Parameters)

### Backward Compatibility
- v2.0.1 functionality preserved (defaults to Bundle format)
- Version detection based on existing `suite_id` patterns (`v220` vs `v201`)

---

## End-to-End UI Validation Steps – PAS v2.2.0 `$inquire` Response Format

### Objective

Validate that the PAS Test Kit correctly supports the updated PAS v2.2.0 `$inquire` response format where the response is returned as a **Parameters resource containing one or more Bundles**, while maintaining full backward compatibility with PAS v2.0.1.

---

### Prerequisites

- Inferno Da Vinci PAS Test Kit running locally
- Branch containing this PR checked out (`support-v2.2.0`)

### Validation Workflow Overview

The validation consists of:

1. Running the Client Suite v2.2.0 as a mock PAS server
2. Running the Server Suite v2.2.0 as the test client
3. Executing the `$inquire` workflow
4. Confirming that Parameters-based responses are accepted and processed
5. Verifying backward compatibility with v2.0.1 behavior

---

### Step 1: Set Up Client Suite (TAB 1)

1. Open the **Da Vinci PAS Client Suite v2.2.0**
2. For **"Client Security Type"**, select **"Other Authentication"**
3. Click **"Start Testing"** to create a testing session
4. From the **Preset** dropdown (top-left), select **"Run Against the PAS Server Suite"** - this auto-populates the input fields, setting up Inferno to simulate a PAS server with denied and pended responses

---

### Step 2: Set Up Server Suite (TAB 2)

1. Open the **Da Vinci PAS Server Suite v2.2.0**
2. Click **"Start Testing"** to create a testing session
3. From the **Preset** dropdown (top-left), select **"Run Against the PAS Client Suite"** - this auto-populates the input fields, pointing the server suite to the Client Suite's simulated server URL

---

### Step 3: Run the $inquire Tests

Navigate to **"3.2 $inquire Element Support"** in the Server Suite and run the tests.

1. Confirm **"3.2.1.02 Submission of a claim to the $inquire operation succeeds"** - the `$inquire` request is sent and a response is received
2. Confirm **"3.2.1.03 Server $inquire Response Bundle is conformant"** - open the **Response** tab and verify the response is a `Parameters` resource (not a direct `Bundle`)
3. Confirm **"3.2.3 $inquire Response Must Support"** - resources are now correctly extracted from inside `parameter[].resource.entry[]`

> **Note:** Some tests may still fail due to missing must-support elements in the data. This is expected and unrelated to the format fix. The key validation here is that the response format is `Parameters` and resources are being extracted correctly from it.

---

### Step 4: Verify the $inquire Response Format

1. Click on test **"3.2.1.03 Server $inquire Response Bundle is conformant"**
2. Open the **Response** tab
3. Confirm the response is a `Parameters` resource (not a direct `Bundle`):

**Before fix - v2.0.1 format (direct Bundle):**
```json
{
  "id": "e52da946-df18-4d7c-9d79-de7aa79fa270",
  "meta": {
    "profile": [
      "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-response-bundle"
    ]
  },
  "type": "collection",
  "timestamp": "2026-02-09T10:08:29Z",
  "entry": [
    {
      "fullUrl": "urn:uuid:0e821ec1-f076-4607-a019-2fcd749decd1",
      "resource": {
        "id": "0e821ec1-f076-4607-a019-2fcd749decd1",
        "meta": {
          "profile": [
            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claiminquiryresponse"
          ]
        },
        "status": "active",
        "type": {
          "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/claim-type", "code": "professional" }]
        },
        "use": "preauthorization",
        "patient": { "reference": "http://davinci-pas.org/fhir/Patient/SubscriberExample" },
        "created": "2026-02-09T10:08:29Z",
        "insurer": { "reference": "http://davinci-pas.org/fhir/Organization/InsurerExample" },
        "requestor": { "reference": "http://davinci-pas.org/fhir/Organization/UMOExample" },
        "outcome": "complete",
        "resourceType": "ClaimResponse"
      }
    },
    {
      "fullUrl": "http://davinci-pas.org/fhir/Patient/SubscriberExample",
      "resource": {
        "id": "SubscriberExample",
        "meta": {
          "profile": [
            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-subscriber"
          ]
        },
        "name": [{ "family": "SMITH", "given": ["JOE"] }],
        "gender": "male",
        "birthDate": "1987-02-20",
        "resourceType": "Patient"
      }
    },
    {
      "fullUrl": "http://davinci-pas.org/fhir/Organization/InsurerExample",
      "resource": {
        "id": "InsurerExample",
        "meta": {
          "profile": [
            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-insurer"
          ]
        },
        "name": "MARYLAND CAPITAL INSURANCE COMPANY",
        "resourceType": "Organization"
      }
    },
    {
      "fullUrl": "http://davinci-pas.org/fhir/Organization/UMOExample",
      "resource": {
        "id": "UMOExample",
        "meta": {
          "profile": [
            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-requestor"
          ]
        },
        "name": "DR. JOE SMITH CORPORATION",
        "resourceType": "Organization"
      }
    }
  ],
  "resourceType": "Bundle"
}
```

**After fix - v2.2.0 format (Bundle wrapped in Parameters):**
```json
{
  "resourceType": "Parameters",
  "parameter": [
    {
      "name": "return",
      "resource": {
        "id": "7e9deb44-469a-44c1-a3e4-5c4ac2a41203",
        "meta": {
          "profile": [
            "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-response-bundle"
          ]
        },
        "type": "collection",
        "timestamp": "2026-02-10T10:01:02Z",
        "entry": [
          {
            "fullUrl": "urn:uuid:bedb08b3-de35-4151-adf0-861c3f624aec",
            "resource": {
              "id": "bedb08b3-de35-4151-adf0-861c3f624aec",
              "meta": {
                "profile": [
                  "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claiminquiryresponse"
                ]
              },
              "status": "active",
              "type": {
                "coding": [{ "system": "http://terminology.hl7.org/CodeSystem/claim-type", "code": "professional" }]
              },
              "use": "preauthorization",
              "patient": { "reference": "http://davinci-pas.org/fhir/Patient/SubscriberExample" },
              "created": "2026-02-10T10:01:02Z",
              "insurer": { "reference": "http://davinci-pas.org/fhir/Organization/InsurerExample" },
              "requestor": { "reference": "http://davinci-pas.org/fhir/Organization/UMOExample" },
              "outcome": "complete",
              "resourceType": "ClaimResponse"
            }
          },
          {
            "fullUrl": "http://davinci-pas.org/fhir/Patient/SubscriberExample",
            "resource": {
              "id": "SubscriberExample",
              "meta": {
                "profile": [
                  "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-subscriber"
                ]
              },
              "name": [{ "family": "SMITH", "given": ["JOE"] }],
              "gender": "male",
              "birthDate": "1987-02-20",
              "resourceType": "Patient"
            }
          },
          {
            "fullUrl": "http://davinci-pas.org/fhir/Organization/InsurerExample",
            "resource": {
              "id": "InsurerExample",
              "meta": {
                "profile": [
                  "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-insurer"
                ]
              },
              "name": "MARYLAND CAPITAL INSURANCE COMPANY",
              "resourceType": "Organization"
            }
          },
          {
            "fullUrl": "http://davinci-pas.org/fhir/Organization/UMOExample",
            "resource": {
              "id": "UMOExample",
              "meta": {
                "profile": [
                  "http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-requestor"
                ]
              },
              "name": "DR. JOE SMITH CORPORATION",
              "resourceType": "Organization"
            }
          }
        ],
        "resourceType": "Bundle"
      }
    }
  ]
}
```

**Expected response (multiple returns - edge case):**
```json
{
  "resourceType": "Parameters",
  "parameter": [
    {
      "name": "return",
      "resource": {
        "resourceType": "Bundle",
        "type": "collection",
        "entry": [ ... ]
      }
    },
    {
      "name": "return",
      "resource": {
        "resourceType": "Bundle",
        "type": "collection",
        "entry": [ ... ]
      }
    }
  ]
}
```

---

### Step 5: Verify Test Results

| Test | Expected Result |
|------|----------------|
| 3.2.1.02 Submission of a claim to the $inquire operation succeeds | Request sent, response received |
| 3.2.1.03 Server $inquire Response Bundle is conformant | Response is `Parameters` (format fix confirmed) |
| 3.2.3.01 All must support elements for PAS Inquiry Response Bundle | May still fail due to missing data elements (unrelated to this fix) |
| 3.2.3.02 All must support elements for PAS Claim Inquiry Response | May still fail due to missing data elements (unrelated to this fix) |

> **Key indicator of success**: The response `resourceType` is `"Parameters"` and resources are being extracted from `parameter[].resource.entry[]` correctly - regardless of individual must-support test outcomes.

---

### Step 6: Verify Edge Cases

#### Case 1: Single Bundle returned
- Run **"3.2.1 Submission of claims to the $inquire operation"**
- Confirm `Parameters` contains **one** `return` parameter with a Bundle

#### Case 2: Multiple Bundles returned
- Confirm `Parameters` contains **multiple** `return` parameters, each with a valid Bundle

#### Case 3: Empty response
- Confirm `Parameters` with an **empty** `parameter` array is handled gracefully

---

### Step 7: Verify No Regression on v2.0.1 Tests

1. Switch to the **Da Vinci PAS Server Suite v2.0.1**
2. Run the `$inquire` tests
3. Confirm the response is still a direct `Bundle` (v2.0.1 format)
4. Confirm all existing v2.0.1 tests pass without any regressions