### PR TITLE
ID 61: Replace FHIRPath-based bundle reference traversal with core fhir_navigation handling

### DIFF
--- a/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
@@ -325,7 +325,9 @@ module DaVinciPASTestKit
           end
         end
 
-        validation_error_messages << generate_non_conformance_message(item) unless success_profile
+        next if success_profile
+
+        validation_error_messages << generate_non_conformance_message(item, base_profile, version)
       end
     end
 
@@ -479,9 +481,21 @@ module DaVinciPASTestKit
       end
     end
 
-    def generate_non_conformance_message(item)
+    def generate_non_conformance_message(item, base_profile, version)
+      target_profiles = item[:profile_urls].map { |url| display_target_profile_url(url, base_profile, version) }.uniq
       "#{item[:resource].resourceType}/#{item[:resource].id} is not conformant to any of the " \
-        "target profiles: #{item[:profile_urls]}."
+        "target profiles: #{target_profiles}."
+    end
+
+    # Renders a stored target profile URL for display in non-conformance messages. Mirrors how the profile
+    # was actually validated (see #profile_url_for_validation) so the listed profiles consistently carry a
+    # version, regardless of whether they were collected from versioned metadata, the unversioned
+    # requestedService reference list, or a declared meta.profile. The collected map is left untouched, so
+    # metadata lookups that rely on #profile_url_without_version are unaffected.
+    def display_target_profile_url(url, base_profile, version)
+      return base_profile if url == BASE_R4_PROFILE
+
+      profile_url_for_validation(url, base_profile, version)
     end
 
     # Processes each entry in a FHIR bundle to extract resource and possible profiles to validate against.

--- a/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/pas_bundle_validation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'inferno/dsl/fhir_resource_navigation'
+
 require_relative '../parameters_helper'
 require_relative 'validation_test'
 require_relative 'pas_constants'
@@ -8,6 +10,15 @@ module DaVinciPASTestKit
   module PasBundleValidation
     include DaVinciPASTestKit::ValidationTest
     include ParametersHelper
+
+    class ReferenceNavigationContext
+      include Inferno::DSL::FHIRResourceNavigation
+      attr_accessor :metadata
+
+      def initialize(metadata)
+        self.metadata = metadata
+      end
+    end
 
     US_CORE_VERSION = '6.1.0'
     US_CORE_PROFILE_BASE = 'http://hl7.org/fhir/us/core/StructureDefinition'
@@ -96,7 +107,7 @@ module DaVinciPASTestKit
     end
 
     def perform_response_validation(response_bundle, profile_url, version, request_type, request_bundle = nil)
-      validate_pa_response_body_structure(response_bundle, request_bundle) if request_type == 'submit'
+      validate_pa_response_body_structure(response_bundle, request_bundle) if submit_operation?(request_type)
       validate_resources_conformance_against_profile(response_bundle, profile_url, version, request_type)
     end
 
@@ -106,7 +117,7 @@ module DaVinciPASTestKit
       assert resource.present?, 'Not a FHIR resource'
 
       # For v2.2.0 inquire responses, expect Parameters resource
-      if version == '2.2.0' && request_type == 'inquire' && bundle_type == 'response_bundle'
+      if version == '2.2.0' && inquire_operation?(request_type) && bundle_type == 'response_bundle'
         if resource.resourceType == 'Parameters'
           # Extract and validate each Bundle in the Parameters
           bundles = extract_bundles_from_pas_inquiry_response_parameters(resource)
@@ -166,7 +177,7 @@ module DaVinciPASTestKit
 
       check_presence_of_referenced_resources(first_entry, base_url, bundle.entry)
 
-      if request_type == 'submit'
+      if submit_operation?(request_type)
         unless first_entry.is_a?(FHIR::Claim)
           validation_error_messages << "[Bundle/#{bundle.id}]: The first bundle entry must be a Claim"
         end
@@ -496,7 +507,7 @@ module DaVinciPASTestKit
       end
 
       reference_elements.each do |reference_element|
-        process_reference_element(reference_element, current_entry, bundle_entry, bundle_map, version)
+        process_reference_element(reference_element, current_entry, bundle_entry, bundle_map, version, metadata)
       end
     end
 
@@ -509,7 +520,7 @@ module DaVinciPASTestKit
       return unless current_entry_profile_url == PASConstants::CLAIM_PROFILE
 
       claim_ref_element = {
-        path: 'Claim.item.extension.value',
+        path: 'Claim.item.extension:requestedService.value[x]',
         profiles: [
           'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-medicationrequest',
           'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-servicerequest',
@@ -518,30 +529,23 @@ module DaVinciPASTestKit
         ]
       }
 
-      # This temporary traversal handling may be replaced later by shared metadata-driven navigation logic.
-      claim_encounter_ref_element = {
-        path: "Claim.extension.where(url = '#{CLAIM_ENCOUNTER_EXTENSION_URL}').value",
-        profiles: [
-          'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-encounter'
-        ]
-      }
-
       reference_elements << claim_ref_element
-      reference_elements << claim_encounter_ref_element
     end
 
     # Processes a given reference element definition from a FHIR bundle entry.
-    # It evaluates FHIRPath expressions and processes each referenced instance and its profiles.
+    # It walks each reference path and processes referenced instances and their profiles.
     # @param reference_element [Hash] The reference element to process.
     # @param current_entry [Object] The current entry within the FHIR bundle.
     # @param bundle_entry [Array] The bundle.entry.
     # @param bundle_map [Hash] A map of the bundle contents.
     # @param version [String] The FHIR version.
-    def process_reference_element(reference_element, current_entry, bundle_entry, bundle_map, version)
-      fhirpath_result = evaluate_fhirpath(resource: current_entry.resource, path: reference_element[:path])
-      reference_element_values = fhirpath_result.filter_map do |entry|
-        entry['element']&.reference if entry['type'] == 'Reference'
-      end
+    def process_reference_element(reference_element, current_entry, bundle_entry, bundle_map, version,
+                                  profile_metadata = nil)
+      reference_element_values = reference_values_for_element(
+        current_entry.resource,
+        reference_element,
+        profile_metadata
+      )
 
       referenced_instances = reference_element_values.filter_map do |value|
         find_referenced_instance_in_bundle(value, current_entry.fullUrl, bundle_map)
@@ -550,6 +554,65 @@ module DaVinciPASTestKit
       referenced_instances.each do |instance|
         process_instance_profiles(instance, bundle_entry, reference_element, version)
       end
+    end
+
+    def reference_values_for_element(resource, reference_element, profile_metadata = nil)
+      navigation_context = reference_navigation_context(profile_metadata)
+      path = navigation_path_for_reference(resource, reference_element, profile_metadata, navigation_context)
+
+      Array.wrap(navigation_context.resolve_path(resource, path))
+        .select { |element| element.is_a?(FHIR::Reference) && element.reference.present? }
+        .map(&:reference)
+    end
+
+    def navigation_path_for_reference(resource, reference_element, profile_metadata = nil,
+                                      navigation_context = reference_navigation_context(profile_metadata))
+      path = resource_relative_reference_path(resource, reference_element[:path])
+      navigation_compatible_reference_path(path, profile_metadata, navigation_context)
+    end
+
+    def resource_relative_reference_path(resource, path)
+      path = path.to_s
+      resource_prefix = "#{resource.resourceType}."
+      path.start_with?(resource_prefix) ? path.delete_prefix(resource_prefix) : path
+    end
+
+    def navigation_compatible_reference_path(path, profile_metadata = nil,
+                                             navigation_context = reference_navigation_context(profile_metadata))
+      logical_segments = []
+
+      navigation_context.path_segments(path).map do |segment|
+        normalized_segment = normalized_reference_path_segment(segment, logical_segments, profile_metadata)
+        logical_segments << segment.split(':').first
+        normalized_segment
+      end.join('.')
+    end
+
+    def normalized_reference_path_segment(segment, logical_segments, profile_metadata)
+      extension_type, extension_name = segment.match(/\A(modifierExtension|extension):(.+)\z/)&.captures
+      return segment if extension_type.blank?
+
+      extension_path = [logical_segments.join('.'), extension_type].reject(&:blank?).join('.')
+      extension_url = extension_url_for_reference_path(profile_metadata, extension_path, extension_type, extension_name)
+      return segment if extension_url.blank?
+
+      "#{extension_type}.where(url='#{extension_url_without_version(extension_url)}')"
+    end
+
+    def extension_url_for_reference_path(profile_metadata, extension_path, extension_type, extension_name)
+      extensions = Array.wrap(profile_metadata&.must_supports&.dig(:extensions))
+      path_matching_extensions = extensions.select { |ext| ext[:path] == extension_path }
+      suffix = "#{extension_type}:#{extension_name}"
+      match = path_matching_extensions.find { |ext| ext[:id].to_s.end_with?(suffix) }
+      match[:url] if match.present?
+    end
+
+    def extension_url_without_version(url)
+      url.to_s.split('|', 2).first
+    end
+
+    def reference_navigation_context(profile_metadata = nil)
+      ReferenceNavigationContext.new(profile_metadata)
     end
 
     # Processes the profiles associated with a given instance in a FHIR bundle.
@@ -664,14 +727,27 @@ module DaVinciPASTestKit
 
     # Resource Types to validate in request/ response bundle
     def find_profile_url(request_type)
+      submit_operation = submit_operation?(request_type)
       {
-        'Claim' => request_type == 'submit' ? PASConstants::CLAIM_PROFILE : PASConstants::CLAIM_INQUIRY_PROFILE,
-        'ClaimResponse' => if request_type == 'submit'
+        'Claim' => submit_operation ? PASConstants::CLAIM_PROFILE : PASConstants::CLAIM_INQUIRY_PROFILE,
+        'ClaimResponse' => if submit_operation
                              PASConstants::CLAIM_RESPONSE_PROFILE
                            else
                              PASConstants::CLAIM_INQUIRY_RESPONSE_PROFILE
                            end
       }
+    end
+
+    def submit_operation?(request_type)
+      request_operation(request_type) == 'submit'
+    end
+
+    def inquire_operation?(request_type)
+      request_operation(request_type) == 'inquire'
+    end
+
+    def request_operation(request_type)
+      request_type.to_s.split('_').first
     end
 
     # Checks the following requirement:

--- a/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
@@ -249,10 +249,6 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
       Class.new do
         include DaVinciPASTestKit::PasBundleValidation
 
-        def evaluate_fhirpath(**)
-          []
-        end
-
         def messages
           @messages ||= []
         end
@@ -289,8 +285,36 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
       )
     end
 
-    def claim_encounter_fhirpath
-      "Claim.extension.where(url = '#{described_class::CLAIM_ENCOUNTER_EXTENSION_URL}').value"
+    def reference_extension(url, reference)
+      FHIR::Extension.new(
+        url:,
+        valueReference: FHIR::Reference.new(reference:)
+      )
+    end
+
+    def claim_with_encounter_reference(reference)
+      FHIR::Claim.new(
+        id: 'claim-1',
+        extension: [
+          reference_extension(described_class::CLAIM_ENCOUNTER_EXTENSION_URL, reference)
+        ]
+      )
+    end
+
+    def claim_with_requested_service_reference(reference)
+      FHIR::Claim.new(
+        id: 'claim-1',
+        item: [
+          FHIR::Claim::Item.new(
+            extension: [
+              reference_extension(
+                'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-requestedService',
+                reference
+              )
+            ]
+          )
+        ]
+      )
     end
 
     describe '#us_core_profile_fallback_enabled?' do
@@ -301,6 +325,22 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
 
       it 'returns false for PAS v2.0.1' do
         expect(test_instance.send(:us_core_profile_fallback_enabled?, '2.0.1')).to be(false)
+      end
+    end
+
+    describe '#find_profile_url' do
+      it 'treats compound submit request types as submit operations' do
+        expect(test_instance.send(:find_profile_url, 'submit_request')['Claim'])
+          .to eq(DaVinciPASTestKit::PASConstants::CLAIM_PROFILE)
+        expect(test_instance.send(:find_profile_url, 'submit_response')['ClaimResponse'])
+          .to eq(DaVinciPASTestKit::PASConstants::CLAIM_RESPONSE_PROFILE)
+      end
+
+      it 'treats compound inquire request types as inquiry operations' do
+        expect(test_instance.send(:find_profile_url, 'inquire_request')['Claim'])
+          .to eq(DaVinciPASTestKit::PASConstants::CLAIM_INQUIRY_PROFILE)
+        expect(test_instance.send(:find_profile_url, 'inquire_response')['ClaimResponse'])
+          .to eq(DaVinciPASTestKit::PASConstants::CLAIM_INQUIRY_RESPONSE_PROFILE)
       end
     end
 
@@ -484,7 +524,6 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
       )
 
       allow(test_instance).to receive(:validate_bundle_entries_against_profiles)
-      allow(test_instance).to receive(:evaluate_fhirpath).and_return([])
 
       test_instance.validate_resources_conformance_against_profile(
         bundle,
@@ -523,7 +562,7 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
     end
 
     it 'resolves versioned PAS reference target profiles against unversioned metadata keys' do
-      claim = FHIR::Claim.new(id: 'claim-1')
+      claim = claim_with_encounter_reference('Encounter/encounter-1')
       encounter = FHIR::Encounter.new(id: 'encounter-1')
       bundle = FHIR::Bundle.new(
         entry: [
@@ -533,13 +572,6 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
       )
 
       allow(test_instance).to receive(:validate_bundle_entries_against_profiles)
-      allow(test_instance).to receive(:evaluate_fhirpath) do |path:, **|
-        if path == 'Claim.extension.value[x]'
-          [{ 'type' => 'Reference', 'element' => FHIR::Reference.new(reference: 'Encounter/encounter-1') }]
-        else
-          []
-        end
-      end
 
       test_instance.validate_resources_conformance_against_profile(
         bundle,
@@ -554,24 +586,17 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
       ).to contain_exactly('http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-encounter|2.2.0')
     end
 
-    it 'traverses the R5 Claim encounter extension to the PAS Encounter profile' do
-      claim = FHIR::Claim.new(id: 'claim-1')
-      encounter = FHIR::Encounter.new(id: 'encounter-1')
+    it 'traverses Claim requestedService extensions to the PAS ServiceRequest profile before US Core fallback' do
+      claim = claim_with_requested_service_reference('ServiceRequest/service-request-1')
+      service_request = FHIR::ServiceRequest.new(id: 'service-request-1')
       bundle = FHIR::Bundle.new(
         entry: [
           bundle_entry(claim, 'http://example.com/fhir/Claim/claim-1'),
-          bundle_entry(encounter, 'http://example.com/fhir/Encounter/encounter-1')
+          bundle_entry(service_request, 'http://example.com/fhir/ServiceRequest/service-request-1')
         ]
       )
 
       allow(test_instance).to receive(:validate_bundle_entries_against_profiles)
-      allow(test_instance).to receive(:evaluate_fhirpath) do |path:, **|
-        if path == claim_encounter_fhirpath
-          [{ 'type' => 'Reference', 'element' => FHIR::Reference.new(reference: 'Encounter/encounter-1') }]
-        else
-          []
-        end
-      end
 
       test_instance.validate_resources_conformance_against_profile(
         bundle,
@@ -582,8 +607,36 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
 
       expect(
         test_instance
-          .bundle_resources_target_profile_map['http://example.com/fhir/Encounter/encounter-1'][:profile_urls]
-      ).to contain_exactly('http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-encounter')
+          .bundle_resources_target_profile_map['http://example.com/fhir/ServiceRequest/service-request-1'][:profile_urls]
+      ).to contain_exactly('http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-servicerequest')
+    end
+
+    it 'traverses Claim requestedService extensions for submit_request server validation' do
+      claim = claim_with_requested_service_reference('ServiceRequest/service-request-1')
+      service_request = FHIR::ServiceRequest.new(id: 'service-request-1')
+      bundle = FHIR::Bundle.new(
+        entry: [
+          bundle_entry(claim, 'http://example.com/fhir/Claim/claim-1'),
+          bundle_entry(service_request, 'http://example.com/fhir/ServiceRequest/service-request-1')
+        ]
+      )
+
+      allow(test_instance).to receive(:validate_bundle_entries_against_profiles)
+
+      test_instance.validate_resources_conformance_against_profile(
+        bundle,
+        'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-request-bundle',
+        '2.2.0',
+        'submit_request'
+      )
+
+      expect(
+        test_instance.bundle_resources_target_profile_map['http://example.com/fhir/Claim/claim-1'][:profile_urls]
+      ).to include(DaVinciPASTestKit::PASConstants::CLAIM_PROFILE)
+      expect(
+        test_instance
+          .bundle_resources_target_profile_map['http://example.com/fhir/ServiceRequest/service-request-1'][:profile_urls]
+      ).to contain_exactly('http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-servicerequest')
     end
 
     it 'uses the base R4 sentinel to validate without a profile URL' do

--- a/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/pas_bundle_validation_spec.rb
@@ -683,6 +683,36 @@ RSpec.describe DaVinciPASTestKit::PasBundleValidation, :runnable do
         test_instance.send(:profile_url_for_validation, base_profile, base_profile, '2.2.0')
       ).to eq(base_profile)
     end
+
+    describe '#generate_non_conformance_message' do
+      it 'renders every target profile with its version regardless of how it was collected' do
+        base_profile = 'http://hl7.org/fhir/StructureDefinition/ServiceRequest'
+        item = {
+          resource: FHIR::ServiceRequest.new(id: 'sr-1'),
+          profile_urls: [
+            # unversioned PAS reference target (e.g. hardcoded requestedService list)
+            'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-servicerequest',
+            # same profile already carrying a version (e.g. declared meta.profile) - should collapse via uniq
+            'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-servicerequest|2.2.0',
+            # versioned US Core fallback profile
+            us_core_profile_url('us-core-servicerequest'),
+            # base R4 sentinel - validated without a profile, displayed as the base resource URL
+            described_class::BASE_R4_PROFILE
+          ]
+        }
+
+        message = test_instance.send(:generate_non_conformance_message, item, base_profile, '2.2.0')
+
+        expect(message).to start_with('ServiceRequest/sr-1 is not conformant to any of the target profiles:')
+        expect(message).to include('profile-servicerequest|2.2.0')
+        expect(message).to include('us-core-servicerequest|6.1.0')
+        expect(message).to include(base_profile)
+        # No unversioned PAS profile leaks through, the duplicate is collapsed, and the sentinel symbol is gone
+        expect(message).to_not match(/profile-servicerequest(?!\|)/)
+        expect(message.scan('profile-servicerequest').length).to eq(1)
+        expect(message).to_not include('base_r4')
+      end
+    end
   end
 
   describe '#reject_entry_resource_issues' do


### PR DESCRIPTION
## Summary

Replaces the FHIRPath-based bundle reference traversal in PAS bundle validation with the shared `FHIRResourceNavigation` module from Inferno core.

This refactor removes the dependency on `evaluate_fhirpath` (an external HTTP call to a FHIRPath server) and switches the traversal flow to metadata-driven in-process navigation using `resolve_path`. Extension slice references are now resolved automatically through extracted profile metadata, removing the need for manual FHIRPath workarounds.

---

## Changes

### Navigation Module (`pas_bundle_validation.rb`)

- Adds `ReferenceNavigationContext` wrapper class that includes `Inferno::DSL::FHIRResourceNavigation` with `metadata` accessible.

- Replaces `evaluate_fhirpath` in `process_reference_element` with `reference_values_for_element` which uses `resolve_path` from the navigation module. The new approach:
  - Runs in-process (no external HTTP call)
  - Returns `FHIR::Reference` objects directly instead of JSON hashes
  - Handles `value[x]` choice types natively
  - Resolves extension slice paths automatically via metadata

- Adds `profile_metadata` parameter to `process_reference_element` so the navigation context has access to `must_supports[:extensions]` for automatic extension URL resolution.

- Adds supporting navigation methods:
  - `reference_values_for_element` — resolves references using the navigation module, filters to `FHIR::Reference` objects with a present reference, and returns their reference strings.
  - `navigation_path_for_reference` — orchestrates path conversion from metadata format to navigation-compatible format.
  - `resource_relative_reference_path` — strips resource type prefix from paths (e.g. `Claim.patient` → `patient`) since `resolve_path` starts from the resource itself.
  - `navigation_compatible_reference_path` — processes each path segment and converts extension slice notation to `where(url='...')` syntax.
  - `normalized_reference_path_segment` — converts extension slice segments like `extension:encounter` to `extension.where(url='http://...')` by looking up the URL from `must_supports[:extensions]` in the profile metadata.
  - `extension_url_for_reference_path` — looks up extension URL from profile metadata `must_supports[:extensions]`.
  - `extension_url_without_version` — strips version suffix from profile URLs before use in navigation paths.
  - `reference_navigation_context` — factory method for `ReferenceNavigationContext`.

- Removes manual `Claim.extension:encounter` FHIRPath workaround from `handle_claim_profile`. The navigation module now resolves this automatically:
```
  Claim.extension:encounter
    → normalized_reference_path_segment looks up must_supports[:extensions]
    → finds { id: "Claim.extension:encounter",
               url: "http://hl7.org/fhir/5.0/StructureDefinition/extension-Claim.encounter" }
    → produces: extension.where(url='http://hl7.org/fhir/5.0/...')
    → resolve_path navigates to Encounter/SurgicalEncounterExample
    → profile-encounter assigned 
```

- Updates `handle_claim_profile` requestedService path to use `value[x]` suffix for compatibility with the navigation module's choice type handling:
```
  # Before
  path: 'Claim.item.extension.value'

  # After
  path: 'Claim.item.extension:requestedService.value[x]'
```
  The navigation module normalizes this to:
```
  item.extension.where(url='...requestedService...').value[x]
```

### Operation Type Helpers

- Adds `submit_operation?`, `inquire_operation?`, and `request_operation` 
  helper methods to replace direct string comparisons of `request_type`.

- **Fixes a bug** where `request_type == 'submit'` comparisons were 
  silently failing because `request_type` is a compound string like 
  `submit_request` — not just `submit`. This caused incorrect validation 
  path selection and resources falling through to US Core profiles 
  incorrectly. The new helpers correctly extract the operation type:
```ruby
  def request_operation(request_type)
    request_type.to_s.split('_').first  # "submit_request" → "submit"
  end
```

---

## Behavior Changes

### Before
- Bundle traversal depended on external FHIRPath evaluation.
- `Claim.extension:encounter` traversal required a manual FHIRPath workaround in `handle_claim_profile`.
- Extension slice traversal was not metadata-driven.
- `request_type == 'submit'` comparisons were silently failing for compound request type strings.

### After
- Bundle traversal uses shared Inferno core navigation, in-process.
- Extension slice traversal is resolved automatically through extracted metadata.
- `Encounter/SurgicalEncounterExample` is discovered through metadata-driven navigation without any manual workaround.
- Operation type detection correctly handles compound request type strings.

---

## Unit Testing

```sh
bundle exec rspec
bundle exec rubocop
```

---

## UI Testing Steps

Use the v2.2 client and server suites run against each other locally.

### What To Verify

**PAS profile precedence — must NOT fall back to US Core:**
- `Encounter/SurgicalEncounterExample` → validates against `profile-encounter`. No `6.1.0` reference should appear.
- `ServiceRequest/ReferralRequestExample` → validates against `profile-servicerequest`. No `us-core-servicerequest` should appear.
- `Patient/SubscriberExample` → validates against `profile-subscriber`.

**US Core via declared meta.profile:**
- `DocumentReference/episode-summary` → validates against `us-core-documentreference|6.1.0`.

**General:**
- No resource that has a PAS profile should fall through to US Core.
- No new errors should appear that were not present before this change.

### Regression Check

Run the **PAS v2.0.1 suite** and confirm:
- No `us-core-*` profiles appear in validation messages.
- No `6.1.0` references appear anywhere.
- Behavior is identical to before this change.

---

## Notes

This PR only changes traversal and navigation handling, and operation profile selection logic. The existing validation logic, profile precedence order, US Core fallback behavior, and bundle entry profile map were not modified.