### PR TITLE
ID-148 Make non-ClaimResponse must support tests optional for v2.2.1 client …

### DIFF
--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_must_support_group.rb
@@ -33,14 +33,11 @@ module DaVinciPASTestKit
         
       )
       run_as_group
-      optional
 
       test from: :pas_client_v221_inquire_request_must_support_pas_inquiry_request_bundle do
         optional
       end
-      test from: :pas_client_v221_inquire_request_must_support_claim_inquiry do
-        optional
-      end
+      test from: :pas_client_v221_inquire_request_must_support_claim_inquiry
       test from: :pas_client_v221_inquire_request_must_support_coverage do
         optional
       end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_must_support_group.rb
@@ -33,16 +33,35 @@ module DaVinciPASTestKit
         
       )
       run_as_group
-      
-      test from: :pas_client_v221_inquire_request_must_support_pas_inquiry_request_bundle
-      test from: :pas_client_v221_inquire_request_must_support_claim_inquiry
-      test from: :pas_client_v221_inquire_request_must_support_coverage
-      test from: :pas_client_v221_inquire_request_must_support_insurer
-      test from: :pas_client_v221_inquire_request_must_support_requestor
-      test from: :pas_client_v221_inquire_request_must_support_beneficiary
-      test from: :pas_client_v221_inquire_request_must_support_subscriber
-      test from: :pas_client_v221_inquire_request_must_support_practitioner
-      test from: :pas_client_v221_inquire_request_must_support_practitioner_role
+      optional
+
+      test from: :pas_client_v221_inquire_request_must_support_pas_inquiry_request_bundle do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_claim_inquiry do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_coverage do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_insurer do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_requestor do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_beneficiary do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_subscriber do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_practitioner do
+        optional
+      end
+      test from: :pas_client_v221_inquire_request_must_support_practitioner_role do
+        optional
+      end
     end
   end
 end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_response_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_response_must_support_group.rb
@@ -39,9 +39,7 @@ module DaVinciPASTestKit
       test from: :pas_client_v221_inquire_response_must_support_pas_inquiry_response_bundle do
         optional
       end
-      test from: :pas_client_v221_inquire_response_must_support_claiminquiryresponse do
-        config(options: { user_input_validation: false })
-      end
+      test from: :pas_client_v221_inquire_response_must_support_claiminquiryresponse
       test from: :pas_client_v221_inquire_response_must_support_insurer do
         optional
       end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_response_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_response_must_support_group.rb
@@ -36,14 +36,30 @@ module DaVinciPASTestKit
       )
       run_as_group
 
-      test from: :pas_client_v221_inquire_response_must_support_pas_inquiry_response_bundle
-      test from: :pas_client_v221_inquire_response_must_support_claiminquiryresponse
-      test from: :pas_client_v221_inquire_response_must_support_insurer
-      test from: :pas_client_v221_inquire_response_must_support_requestor
-      test from: :pas_client_v221_inquire_response_must_support_beneficiary
-      test from: :pas_client_v221_inquire_response_must_support_practitioner
-      test from: :pas_client_v221_inquire_response_must_support_practitioner_role
-      test from: :pas_client_v221_inquire_response_must_support_task
+      test from: :pas_client_v221_inquire_response_must_support_pas_inquiry_response_bundle do
+        optional
+      end
+      test from: :pas_client_v221_inquire_response_must_support_claiminquiryresponse do
+        config(options: { user_input_validation: false })
+      end
+      test from: :pas_client_v221_inquire_response_must_support_insurer do
+        optional
+      end
+      test from: :pas_client_v221_inquire_response_must_support_requestor do
+        optional
+      end
+      test from: :pas_client_v221_inquire_response_must_support_beneficiary do
+        optional
+      end
+      test from: :pas_client_v221_inquire_response_must_support_practitioner do
+        optional
+      end
+      test from: :pas_client_v221_inquire_response_must_support_practitioner_role do
+        optional
+      end
+      test from: :pas_client_v221_inquire_response_must_support_task do
+        optional
+      end
       test from: :pas_client_v221_response_attest,
            title: 'Confirm that the client handled the $inquire response must support elements (Attestation)',
            description: %(

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_response_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_inquire_response_must_support_group.rb
@@ -39,7 +39,9 @@ module DaVinciPASTestKit
       test from: :pas_client_v221_inquire_response_must_support_pas_inquiry_response_bundle do
         optional
       end
-      test from: :pas_client_v221_inquire_response_must_support_claiminquiryresponse
+      test from: :pas_client_v221_inquire_response_must_support_claiminquiryresponse do
+        config(options: { user_input_validation: false })
+      end
       test from: :pas_client_v221_inquire_response_must_support_insurer do
         optional
       end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_must_support_group.rb
@@ -41,18 +41,41 @@ module DaVinciPASTestKit
         
       )
       run_as_group
-      
-      test from: :pas_client_v221_must_support_request_profiles
-      test from: :pas_client_v221_submit_request_must_support_pas_request_bundle
-      test from: :pas_client_v221_submit_request_must_support_claim_update
-      test from: :pas_client_v221_submit_request_must_support_coverage
-      test from: :pas_client_v221_submit_request_must_support_encounter
-      test from: :pas_client_v221_submit_request_must_support_insurer
-      test from: :pas_client_v221_submit_request_must_support_requestor
-      test from: :pas_client_v221_submit_request_must_support_beneficiary
-      test from: :pas_client_v221_submit_request_must_support_subscriber
-      test from: :pas_client_v221_submit_request_must_support_practitioner
-      test from: :pas_client_v221_submit_request_must_support_practitioner_role
+      optional
+
+      test from: :pas_client_v221_must_support_request_profiles do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_pas_request_bundle do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_claim_update do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_coverage do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_encounter do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_insurer do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_requestor do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_beneficiary do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_subscriber do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_practitioner do
+        optional
+      end
+      test from: :pas_client_v221_submit_request_must_support_practitioner_role do
+        optional
+      end
     end
   end
 end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_must_support_group.rb
@@ -41,7 +41,6 @@ module DaVinciPASTestKit
         
       )
       run_as_group
-      optional
 
       test from: :pas_client_v221_must_support_request_profiles do
         optional
@@ -49,9 +48,7 @@ module DaVinciPASTestKit
       test from: :pas_client_v221_submit_request_must_support_pas_request_bundle do
         optional
       end
-      test from: :pas_client_v221_submit_request_must_support_claim_update do
-        optional
-      end
+      test from: :pas_client_v221_submit_request_must_support_claim_update
       test from: :pas_client_v221_submit_request_must_support_coverage do
         optional
       end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_response_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_response_must_support_group.rb
@@ -38,15 +38,33 @@ module DaVinciPASTestKit
       )
       run_as_group
 
-      test from: :pas_client_v221_submit_response_must_support_pas_response_bundle
-      test from: :pas_client_v221_submit_response_must_support_claimresponse
-      test from: :pas_client_v221_submit_response_must_support_communication_request
-      test from: :pas_client_v221_submit_response_must_support_insurer
-      test from: :pas_client_v221_submit_response_must_support_requestor
-      test from: :pas_client_v221_submit_response_must_support_beneficiary
-      test from: :pas_client_v221_submit_response_must_support_practitioner
-      test from: :pas_client_v221_submit_response_must_support_practitioner_role
-      test from: :pas_client_v221_submit_response_must_support_task
+      test from: :pas_client_v221_submit_response_must_support_pas_response_bundle do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_claimresponse do
+        config(options: { user_input_validation: false })
+      end
+      test from: :pas_client_v221_submit_response_must_support_communication_request do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_insurer do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_requestor do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_beneficiary do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_practitioner do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_practitioner_role do
+        optional
+      end
+      test from: :pas_client_v221_submit_response_must_support_task do
+        optional
+      end
       test from: :pas_client_v221_response_attest,
            title: 'Confirm that the client handled the $submit response must support elements (Attestation)',
            description: %(

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_response_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_response_must_support_group.rb
@@ -41,9 +41,7 @@ module DaVinciPASTestKit
       test from: :pas_client_v221_submit_response_must_support_pas_response_bundle do
         optional
       end
-      test from: :pas_client_v221_submit_response_must_support_claimresponse do
-        config(options: { user_input_validation: false })
-      end
+      test from: :pas_client_v221_submit_response_must_support_claimresponse
       test from: :pas_client_v221_submit_response_must_support_communication_request do
         optional
       end

--- a/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_response_must_support_group.rb
+++ b/lib/davinci_pas_test_kit/client/generated/v2.2.1/pas_client_submit_response_must_support_group.rb
@@ -41,7 +41,9 @@ module DaVinciPASTestKit
       test from: :pas_client_v221_submit_response_must_support_pas_response_bundle do
         optional
       end
-      test from: :pas_client_v221_submit_response_must_support_claimresponse
+      test from: :pas_client_v221_submit_response_must_support_claimresponse do
+        config(options: { user_input_validation: false })
+      end
       test from: :pas_client_v221_submit_response_must_support_communication_request do
         optional
       end


### PR DESCRIPTION
# Summary
Made non-ClaimResponse must support tests optional for v2.2.1 client suite in:
- pas_client_inquire_must_support_group.rb
- pas_client_inquire_response_must_support_group.rb
- pas_client_submit_must_support_group.rb
- pas_client_submit_response_must_support_group.rb

