### PR TITLE
ID-88: Narrow the x12 validator message filter and apply it to both Client and Server suites

### DIFF
--- a/lib/davinci_pas_test_kit/client/v2.0.1/client_suite.rb
+++ b/lib/davinci_pas_test_kit/client/v2.0.1/client_suite.rb
@@ -98,7 +98,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
+          V201_SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/lib/davinci_pas_test_kit/client/v2.2.1/client_suite.rb
+++ b/lib/davinci_pas_test_kit/client/v2.2.1/client_suite.rb
@@ -87,7 +87,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
+          V221_SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
       end
 

--- a/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
@@ -18,6 +18,11 @@ module DaVinciPASTestKit
     # The NUBC revenue code system is proprietary as well and cannot be resolved. The test kit's
     # example data references it under both of the URLs the IG has used for it.
     %r{A definition for CodeSystem 'https://www\.nubc\.org/(revenue-code|CodeSystem/RevenueCodes)' could not be found, so the code cannot be validated},
+    # Because that code system is unavailable, membership in the PAS-defined value set built on it
+    # cannot be checked either. Claim.item.revenue is must-support (not required), so the IG examples
+    # leave it empty and the IG QA never hits this, but the must support tests populate it, so the
+    # code cannot be checked against the value set and the error is unactionable.
+    "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' (http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes",
     # The IG references this draft code system with bindings stronger than example.
     'Reference to draft CodeSystem http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes',
     # IG defect: these extensions are marked must-support at a location that their own context
@@ -36,8 +41,10 @@ module DaVinciPASTestKit
     # must-support on ClaimResponse.item.
     %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-communicatedDiagnosis( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?ClaimResponse\.item\]},
     # extension-productOrServiceCodeEnd: context lists Claim.item/ClaimResponse, but
-    # profile-servicerequest marks it must-support on ServiceRequest.
+    # profile-servicerequest marks it must-support on ServiceRequest and profile-claimresponse marks
+    # it must-support on ClaimResponse.addItem.
     %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd( v[\d.]+)? is not allowed to be used at this point \(this element is \[ServiceRequest\]},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?ClaimResponse\.addItem\]},
     # extension-itemAuthorizedProvider: context allows ExplanationOfBenefit/ClaimResponse.item only,
     # but profile-claimresponse marks it must-support on the ClaimResponse root.
     %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-itemAuthorizedProvider( v[\d.]+)? is not allowed to be used at this point \(this element is \[ClaimResponse\]},

--- a/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
@@ -12,9 +12,11 @@ module DaVinciPASTestKit
   # rubocop:disable Layout/LineLength
   V221_SUPPRESSIONS = [
     # X12 value set and code system definitions are proprietary and not available to the validator,
-    # so resolution failures for them are not actionable by users.
-    %r{ValueSet 'https://valueset\.x12\.org/[^']+' not found},
-    %r{A definition for CodeSystem 'https://codesystem\.x12\.org/[^']+' could not be found, so the code cannot be validated},
+    # so resolution failures for them are not actionable by users. The IG references X12 URLs under
+    # both x12.org subdomains, and uses valueset.x12.org URLs as code system URLs in some places, so
+    # both patterns accept either subdomain.
+    %r{ValueSet 'https://(?:valueset|codesystem)\.x12\.org/[^']+' not found},
+    %r{A definition for CodeSystem 'https://(?:codesystem|valueset)\.x12\.org/[^']+' could not be found, so the code cannot be validated},
     # The NUBC revenue code system is proprietary as well and cannot be resolved. The test kit's
     # example data references it under both of the URLs the IG has used for it.
     %r{A definition for CodeSystem 'https://www\.nubc\.org/(revenue-code|CodeSystem/RevenueCodes)' could not be found, so the code cannot be validated},

--- a/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
@@ -25,6 +25,10 @@ module DaVinciPASTestKit
     # leave it empty and the IG QA never hits this, but the must support tests populate it, so the
     # code cannot be checked against the value set and the error is unactionable.
     "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' (http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes",
+    # These PAS-defined value sets draw all their members from X12 code systems, so membership
+    # cannot be checked and the failure is unactionable. Anchored on each value set's canonical URL.
+    %r{None of the codings provided are in the value set .*http://hl7\.org/fhir/us/davinci-pas/ValueSet/pas-pwk01-attachment-report-type-code},
+    %r{None of the codings provided are in the value set .*http://hl7\.org/fhir/us/davinci-pas/ValueSet/PASCommunicationRequestMedium},
     # The IG references this draft code system with bindings stronger than example.
     'Reference to draft CodeSystem http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes',
     # IG defect: these extensions are marked must-support at a location that their own context

--- a/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
@@ -122,6 +122,10 @@ module DaVinciPASTestKit
       'X12278DiagnosisCodes', # ValueSet includes full ICD-10-CM plus unavailable code systems; validator cannot fully expand
       'X12278RequestedServiceType', # X12 code system included in this PAS-defined value set
       'X12278LocationType', # X12 code system included in this PAS-defined value set
+      # X12 value set definitions are proprietary and unavailable to the validator, so resolution
+      # failures for them are not actionable. Current validator versions quote the URL, which the
+      # exact-string entries from the IG suppression list above no longer match.
+      %r{ValueSet 'https://valueset\.x12\.org/[^']+' not found},
       'ValueSet https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 not found',
       "Error from http://tx.fhir.org/r4: Error:A definition for the value Set 'http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1' could not be found",
       "A definition for CodeSystem 'https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' could not be found, so the code cannot be validated",

--- a/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
@@ -15,40 +15,37 @@ module DaVinciPASTestKit
     # so resolution failures for them are not actionable by users.
     %r{ValueSet 'https://valueset\.x12\.org/[^']+' not found},
     %r{A definition for CodeSystem 'https://codesystem\.x12\.org/[^']+' could not be found, so the code cannot be validated},
-    # The NUBC revenue code system is proprietary as well, so it can be neither resolved nor
-    # expanded within the PAS-defined value set built on it. Code membership failures against that
-    # value set are false positives -- the IG's own examples fail the check.
-    "A definition for CodeSystem 'https://www.nubc.org/revenue-code' could not be found, so the code cannot be validated",
-    "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' (http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes",
-    # Same situation for the PAS-defined X12278RequestedServiceType value set, which draws its
-    # members from unavailable X12 code systems.
-    "None of the codings provided are in the value set 'X12 278 Requested Service Type' (http://hl7.org/fhir/us/davinci-pas/ValueSet/X12278RequestedServiceType",
+    # The NUBC revenue code system is proprietary as well and cannot be resolved. The test kit's
+    # example data references it under both of the URLs the IG has used for it.
+    %r{A definition for CodeSystem 'https://www\.nubc\.org/(revenue-code|CodeSystem/RevenueCodes)' could not be found, so the code cannot be validated},
     # The IG references this draft code system with bindings stronger than example.
     'Reference to draft CodeSystem http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes',
-    # No real content
-    /Details for (.+) matching against profile/,
-    # IG defect: extension context definitions for these extensions don't match where the profiles
-    # place them as must support elements.
-    # extension-authorizationNumber and extension-administrationReferenceNumber context allows
-    # Claim.item only, but profile-claim-base marks them must-support on Claim.extension
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-authorizationNumber( v[\d.]+)? is not allowed to be used at this point},
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-administrationReferenceNumber( v[\d.]+)? is not allowed to be used at this point},
-    # extension-communicatedDiagnosis context only lists Claim, but profile-claimresponse marks it must-support on ClaimResponse.item
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-communicatedDiagnosis( v[\d.]+)? is not allowed to be used at this point},
-    # extension-productOrServiceCodeEnd context only lists Claim.item/ClaimResponse, but profile-servicerequest marks it must-support on ServiceRequest
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd( v[\d.]+)? is not allowed to be used at this point},
-    # extension-infoChanged and modifierextension-infoCancelled context only lists Claim.item,
-    # but profile-claim-base marks them must-support on Claim.supportingInfo as well
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-infoChanged( v[\d.]+)? is not allowed to be used at this point},
-    %r{The modifier extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/modifierextension-infoCancelled( v[\d.]+)? is not allowed to be used at this point},
-    # extension-itemAuthorizedProvider context allows ExplanationOfBenefit/ClaimResponse.item only,
-    # but profile-claimresponse marks ClaimResponse.extension:authorizedProvider as must-support on ClaimResponse root
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-itemAuthorizedProvider( v[\d.]+)? is not allowed to be used at this point},
-    # extension-revenueUnitRateLimit, extension-serviceItemRequestType, extension-certificationType
-    # context prohibits ClaimResponse.addItem, but profile-claimresponse marks all three as must-support there
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-revenueUnitRateLimit( v[\d.]+)? is not allowed to be used at this point},
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-serviceItemRequestType( v[\d.]+)? is not allowed to be used at this point},
-    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-certificationType( v[\d.]+)? is not allowed to be used at this point}
+    # IG defect: these extensions are marked must-support at a location that their own context
+    # definition does not permit, so the validator rejects them where the profile requires them.
+    # Each pattern is anchored to the specific element context that the IG forces (reported by the
+    # validator as "(this element is [...])"), so a genuinely misplaced extension is not suppressed.
+    # extension-authorizationNumber/administrationReferenceNumber: context allows Claim.item only,
+    # but profile-claim-base marks them must-support on Claim.extension.
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-authorizationNumber( v[\d.]+)? is not allowed to be used at this point \(this element is \[Claim\]},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-administrationReferenceNumber( v[\d.]+)? is not allowed to be used at this point \(this element is \[Claim\]},
+    # extension-infoChanged/modifierextension-infoCancelled: context lists Claim.item only, but
+    # profile-claim-base marks them must-support on Claim.supportingInfo as well.
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-infoChanged( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?Claim\.supportingInfo\]},
+    %r{The modifier extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/modifierextension-infoCancelled( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?Claim\.supportingInfo\]},
+    # extension-communicatedDiagnosis: context lists Claim only, but profile-claimresponse marks it
+    # must-support on ClaimResponse.item.
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-communicatedDiagnosis( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?ClaimResponse\.item\]},
+    # extension-productOrServiceCodeEnd: context lists Claim.item/ClaimResponse, but
+    # profile-servicerequest marks it must-support on ServiceRequest.
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd( v[\d.]+)? is not allowed to be used at this point \(this element is \[ServiceRequest\]},
+    # extension-itemAuthorizedProvider: context allows ExplanationOfBenefit/ClaimResponse.item only,
+    # but profile-claimresponse marks it must-support on the ClaimResponse root.
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-itemAuthorizedProvider( v[\d.]+)? is not allowed to be used at this point \(this element is \[ClaimResponse\]},
+    # extension-revenueUnitRateLimit/serviceItemRequestType/certificationType: context prohibits
+    # ClaimResponse.addItem, but profile-claimresponse marks all three must-support there.
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-revenueUnitRateLimit( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?ClaimResponse\.addItem\]},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-serviceItemRequestType( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?ClaimResponse\.addItem\]},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-certificationType( v[\d.]+)? is not allowed to be used at this point \(this element is \[(?:BackboneElement, )?ClaimResponse\.addItem\]}
   ].freeze
 
   # This list captures all validator messages suppressed for the v2.0.1 suites

--- a/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb
@@ -1,5 +1,57 @@
 module DaVinciPASTestKit
-  # This regex captues all known suppressed validator messages
+  # Validator message suppressions, split by suite version:
+  #
+  # * V221_SUPPRESSIONS is the targeted list used by the v2.2.1 suites. Each entry is anchored to a
+  #   specific unactionable failure mode confirmed to still occur in current validator output
+  #   (HL7 validator 6.9.x) for v2.2.1 profiles, IG examples, and test kit payloads.
+  # * LEGACY_SUPPRESSIONS is the previous list, retained unchanged for the v2.0.1 suites.
+  #
+  # The v2.2.1 suites match only V221_SUPPRESSED_MESSAGES; the v2.0.1 suites match the union of
+  # both lists (V201_SUPPRESSED_MESSAGES).
+  #
+  # rubocop:disable Layout/LineLength
+  V221_SUPPRESSIONS = [
+    # X12 value set and code system definitions are proprietary and not available to the validator,
+    # so resolution failures for them are not actionable by users.
+    %r{ValueSet 'https://valueset\.x12\.org/[^']+' not found},
+    %r{A definition for CodeSystem 'https://codesystem\.x12\.org/[^']+' could not be found, so the code cannot be validated},
+    # The NUBC revenue code system is proprietary as well, so it can be neither resolved nor
+    # expanded within the PAS-defined value set built on it. Code membership failures against that
+    # value set are false positives -- the IG's own examples fail the check.
+    "A definition for CodeSystem 'https://www.nubc.org/revenue-code' could not be found, so the code cannot be validated",
+    "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' (http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes",
+    # Same situation for the PAS-defined X12278RequestedServiceType value set, which draws its
+    # members from unavailable X12 code systems.
+    "None of the codings provided are in the value set 'X12 278 Requested Service Type' (http://hl7.org/fhir/us/davinci-pas/ValueSet/X12278RequestedServiceType",
+    # The IG references this draft code system with bindings stronger than example.
+    'Reference to draft CodeSystem http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes',
+    # No real content
+    /Details for (.+) matching against profile/,
+    # IG defect: extension context definitions for these extensions don't match where the profiles
+    # place them as must support elements.
+    # extension-authorizationNumber and extension-administrationReferenceNumber context allows
+    # Claim.item only, but profile-claim-base marks them must-support on Claim.extension
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-authorizationNumber( v[\d.]+)? is not allowed to be used at this point},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-administrationReferenceNumber( v[\d.]+)? is not allowed to be used at this point},
+    # extension-communicatedDiagnosis context only lists Claim, but profile-claimresponse marks it must-support on ClaimResponse.item
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-communicatedDiagnosis( v[\d.]+)? is not allowed to be used at this point},
+    # extension-productOrServiceCodeEnd context only lists Claim.item/ClaimResponse, but profile-servicerequest marks it must-support on ServiceRequest
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd( v[\d.]+)? is not allowed to be used at this point},
+    # extension-infoChanged and modifierextension-infoCancelled context only lists Claim.item,
+    # but profile-claim-base marks them must-support on Claim.supportingInfo as well
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-infoChanged( v[\d.]+)? is not allowed to be used at this point},
+    %r{The modifier extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/modifierextension-infoCancelled( v[\d.]+)? is not allowed to be used at this point},
+    # extension-itemAuthorizedProvider context allows ExplanationOfBenefit/ClaimResponse.item only,
+    # but profile-claimresponse marks ClaimResponse.extension:authorizedProvider as must-support on ClaimResponse root
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-itemAuthorizedProvider( v[\d.]+)? is not allowed to be used at this point},
+    # extension-revenueUnitRateLimit, extension-serviceItemRequestType, extension-certificationType
+    # context prohibits ClaimResponse.addItem, but profile-claimresponse marks all three as must-support there
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-revenueUnitRateLimit( v[\d.]+)? is not allowed to be used at this point},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-serviceItemRequestType( v[\d.]+)? is not allowed to be used at this point},
+    %r{The extension http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/extension-certificationType( v[\d.]+)? is not allowed to be used at this point}
+  ].freeze
+
+  # This list captures all validator messages suppressed for the v2.0.1 suites
   # Source: https://hl7.org/fhir/us/davinci-pas/STU2/qa.html#suppressed
   #
   # Some of the messages in this list are generated by the IG publisher and will never actually come from the
@@ -18,154 +70,148 @@ module DaVinciPASTestKit
   # Also note there is a handful of messages where the official list contains the words "could not be found",
   # where the messages return from the Inferno validator serivce contain the words "is unknown". The
   # corresponding regexes below have a capturing group to account for both cases.
-  #
-  # rubocop:disable Layout/LineLength
-  SUPPRESSED_MESSAGES = Regexp.union(
-    [
-      "Global Profile reference 'http://hl7.org/fhir/us/core/StructureDefinition/patient' from IG http://hl7.org/fhir/us/daf|0 could not be resolved, so has not been checked",
-      %r{Unable to provide support for code system http://terminology\.hl7\.org/CodeSystem/icd9cm},
-      %r{Unable to provide support for code system http://www\.cms\.gov/Medicare/Coding/HCPCSReleaseCodeSets},
-      %r{Unable to provide support for code system https://www\.nubc\.org/CodeSystem/TypeOfBill},
-      %r{Unable to provide support for code system https://www\.nubc\.org/revenue-code},
-      %r{Code System URI 'http://www\.cms\.gov/Medicare/Coding/HCPCSReleaseCodeSets' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://www\.cms\.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' (could not be found|is unknown) so the code cannot be validated},
-      "The definition for the Code System with URI 'https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' doesnt provide any codes so the code cannot be validated",
-      "The definition for the Code System with URI 'https://www.nubc.org/CodeSystem/PatDischargeStatus' doesnt provide any codes so the code cannot be validated",
-      "The definition for the Code System with URI 'https://www.nubc.org/CodeSystem/PointOfOrigin' doesnt provide any codes so the code cannot be validated",
-      "The definition for the Code System with URI 'https://www.nubc.org/CodeSystem/PriorityTypeOfAdmitOrVisit' doesnt provide any codes so the code cannot be validated",
-      %r{Reference to draft item http://hl7\.org/fhir/standards-status},
-      %r{Reference to draft item http://hl7\.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes},
-      "The resource status 'draft' and the standards status 'trial-use' may not be consistent and should be reviewed",
-      %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-request-bundle},
-      %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-response-bundle},
-      %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-request-bundle},
-      %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-response-bundle},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278ConditionCategory},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278ConditionCode},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278FollowUpActionCodes},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278LocationType},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278NutritionOralDietType},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278RejectReasonCodes},
-      %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278RequestedServiceType},
-      'US FHIR Usage rules require that all profiles on Coverage derive from the core US profile',
-      'US FHIR Usage rules require that all profiles on PractitionerRole derive from the core US profile',
-      'US FHIR Usage rules require that all profiles on ServiceRequest derive from the core US profile',
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/1136},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/1321},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/1365},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/755},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/756},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/889},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/901},
-      %r{Unable to provide support for code system https://codesystem\.x12\.org/external/886},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1136' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1321' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1322' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1337' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1338' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1345' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1365' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/1525' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/306' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/584' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/678' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/679' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/755' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/889' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/901' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/923' (could not be found|is unknown) so the code cannot be validated},
-      %r{Code System URI 'https://codesystem\.x12\.org/005010/98' (could not be found|is unknown) so the code cannot be validated},
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000D/INS/1/02/00/1069 on element Coverage.relationship.coding could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/01/00/1315 on element Encounter.type could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/02/00/1314 on element Encounter.hospitalization.admitSource could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/03/00/1352 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/04/00/1345 on element Encounter.extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CR6/1/01/00/923 on element Extension.extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/UM/1/01/00/1525 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/UM/1/05/01/1362 on element Claim.accident.type could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/UM/1/06/00/1338 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/HSD/1/07/00/678 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/HSD/1/08/00/679 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/SV1/1/20/00/1337 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/SV2/1/09/00/1345 on element Claim.item.extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/UM/1/02/00/1322 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365 on element Claim.item.category could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2010A/NM1/1/01/00/98 on element Organization.type could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2010C/INS/1/08/00/584 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2010EA/NM1/1/01/00/98 on element Claim.careTeam.role could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2010EA/PRV/1/03/00/127 on element Claim.careTeam.qualification could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2010F/NM1/1/01/00/98 on element Claim.careTeam.role could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/request/2010F/PRV/1/03/00/127 on element Claim.careTeam.qualification could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/response/2000D/PWK/1/01/00/755 on element CommunicationRequest.category could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/response/2000F/HCR/1/01/00/306 on element Extension.value[x] could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 on element Organization.type could not be resolved',
-      'The valueSet reference https://valueset.x12.org/x217/005010/response/2010EA/NM1/1/01/00/98 on element Extension.extension.value[x] could not be resolved',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CL1/1/01/00/1315 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CL1/1/02/00/1314 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CL1/1/03/00/1352 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CR6/1/01/00/923 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000E/UM/1/01/00/1525 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000E/UM/1/06/00/1338 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000F/HSD/1/07/00/678 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000F/HSD/1/08/00/679 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000F/SV1/1/20/00/1337 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000F/SV2/1/09/00/1345 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000F/UM/1/02/00/1322 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2010A/NM1/1/01/00/98 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/request/2010C/INS/1/08/00/584 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/response/2000D/PWK/1/01/00/755 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/response/2000F/HCR/1/01/00/306 not found',
-      'ValueSet https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 not found',
-      # additional lines added beyond the errors suppressed in the IG
-      'http://hl7.org/fhir/5.0/StructureDefinition/extension-Claim.encounter', # validator bug, https://github.com/hapifhir/org.hl7.fhir.core/issues/1556
-      'X12278DiagnosisCodes', # ValueSet includes full ICD-10-CM plus unavailable code systems; validator cannot fully expand
-      'X12278RequestedServiceType', # X12 code system included in this PAS-defined value set
-      'X12278LocationType', # X12 code system included in this PAS-defined value set
-      # X12 value set definitions are proprietary and unavailable to the validator, so resolution
-      # failures for them are not actionable. Current validator versions quote the URL, which the
-      # exact-string entries from the IG suppression list above no longer match.
-      %r{ValueSet 'https://valueset\.x12\.org/[^']+' not found},
-      'ValueSet https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 not found',
-      "Error from http://tx.fhir.org/r4: Error:A definition for the value Set 'http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1' could not be found",
-      "A definition for CodeSystem 'https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' could not be found, so the code cannot be validated",
-      "A definition for CodeSystem 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets' could not be found, so the code cannot be validated",
-      'could not be found, so the code cannot be validated',
-      'https://www.nubc.org/revenue-code',
-      # supress references to draft code systems that the IG references with bindings stronger than example
-      # looks to just be the PAS Temp Codes
-      'Reference to draft CodeSystem http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes',
-      # no real content
-      /Details for (.+) matching against profile/,
-      ': All OK',
-      # This was ignored natively in the Inferno validator but needs to be ignored by the test kit with the HL7 validator
-      /URL value '.*' does not resolve/,
-      # addition validator clean-up based on Bundle sub-validations where Inferno error supression doesn't
-      # work. The test kit validates these instances individually as well, so they are still checked,
-      # but in a way that Inferno can supress errors
-      'Unable to find a match for profile',
-      'Unable to find a profile match for',
-      # IG defect: extension context definitions for these extensions don't match where the profiles place them
-      # extension-authorizationNumber context allows Claim.item only, but profile-claim-base marks it must-support on Claim.extension
-      /extension-authorizationNumber( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      /extension-administrationReferenceNumber( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      /extension-communicatedDiagnosis( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      # IG defect: extension-productOrServiceCodeEnd context only lists Claim.item/ClaimResponse, but profile-servicerequest marks it must-support on ServiceRequest
-      /extension-productOrServiceCodeEnd( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      # IG defect: extension-infoChanged and modifierextension-infoCancelled context only lists Claim.item,
-      # but profile-claim-base marks them must-support on Claim.supportingInfo as well
-      /extension-infoChanged( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      /modifierextension-infoCancelled( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      # IG defect: extension-itemAuthorizedProvider context allows ExplanationOfBenefit/ClaimResponse.item only,
-      # but profile-claimresponse marks ClaimResponse.extension:authorizedProvider as must-support on ClaimResponse root
-      /extension-itemAuthorizedProvider( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      # IG defect: extension-revenueUnitRateLimit, extension-serviceItemRequestType, extension-certificationType
-      # context prohibits ClaimResponse.addItem, but profile-claimresponse marks all three as must-support there
-      /extension-revenueUnitRateLimit( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      /extension-serviceItemRequestType( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
-      /extension-certificationType( v\d+\.\d+\.\d+)? is not allowed to be used at this point/
-
-    ]
-  )
+  LEGACY_SUPPRESSIONS = [
+    "Global Profile reference 'http://hl7.org/fhir/us/core/StructureDefinition/patient' from IG http://hl7.org/fhir/us/daf|0 could not be resolved, so has not been checked",
+    %r{Unable to provide support for code system http://terminology\.hl7\.org/CodeSystem/icd9cm},
+    %r{Unable to provide support for code system http://www\.cms\.gov/Medicare/Coding/HCPCSReleaseCodeSets},
+    %r{Unable to provide support for code system https://www\.nubc\.org/CodeSystem/TypeOfBill},
+    %r{Unable to provide support for code system https://www\.nubc\.org/revenue-code},
+    %r{Code System URI 'http://www\.cms\.gov/Medicare/Coding/HCPCSReleaseCodeSets' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://www\.cms\.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' (could not be found|is unknown) so the code cannot be validated},
+    "The definition for the Code System with URI 'https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' doesnt provide any codes so the code cannot be validated",
+    "The definition for the Code System with URI 'https://www.nubc.org/CodeSystem/PatDischargeStatus' doesnt provide any codes so the code cannot be validated",
+    "The definition for the Code System with URI 'https://www.nubc.org/CodeSystem/PointOfOrigin' doesnt provide any codes so the code cannot be validated",
+    "The definition for the Code System with URI 'https://www.nubc.org/CodeSystem/PriorityTypeOfAdmitOrVisit' doesnt provide any codes so the code cannot be validated",
+    %r{Reference to draft item http://hl7\.org/fhir/standards-status},
+    %r{Reference to draft item http://hl7\.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes},
+    "The resource status 'draft' and the standards status 'trial-use' may not be consistent and should be reviewed",
+    %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-request-bundle},
+    %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-inquiry-response-bundle},
+    %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-request-bundle},
+    %r{This element does not match any known slice defined in the profile http://hl7\.org/fhir/us/davinci-pas/StructureDefinition/profile-pas-response-bundle},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278ConditionCategory},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278ConditionCode},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278FollowUpActionCodes},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278LocationType},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278NutritionOralDietType},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278RejectReasonCodes},
+    %r{Unable to check whether the code is in the value set http://hl7\.org/fhir/us/davinci-pas/ValueSet/X12278RequestedServiceType},
+    'US FHIR Usage rules require that all profiles on Coverage derive from the core US profile',
+    'US FHIR Usage rules require that all profiles on PractitionerRole derive from the core US profile',
+    'US FHIR Usage rules require that all profiles on ServiceRequest derive from the core US profile',
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/1136},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/1321},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/1365},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/755},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/756},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/889},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/005010/901},
+    %r{Unable to provide support for code system https://codesystem\.x12\.org/external/886},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1136' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1321' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1322' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1337' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1338' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1345' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1365' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/1525' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/306' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/584' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/678' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/679' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/755' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/889' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/901' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/923' (could not be found|is unknown) so the code cannot be validated},
+    %r{Code System URI 'https://codesystem\.x12\.org/005010/98' (could not be found|is unknown) so the code cannot be validated},
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000D/INS/1/02/00/1069 on element Coverage.relationship.coding could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/01/00/1315 on element Encounter.type could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/02/00/1314 on element Encounter.hospitalization.admitSource could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/03/00/1352 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CL1/1/04/00/1345 on element Encounter.extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/CR6/1/01/00/923 on element Extension.extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/UM/1/01/00/1525 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/UM/1/05/01/1362 on element Claim.accident.type could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000E/UM/1/06/00/1338 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/HSD/1/07/00/678 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/HSD/1/08/00/679 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/SV1/1/20/00/1337 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/SV2/1/09/00/1345 on element Claim.item.extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/UM/1/02/00/1322 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365 on element Claim.item.category could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2010A/NM1/1/01/00/98 on element Organization.type could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2010C/INS/1/08/00/584 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2010EA/NM1/1/01/00/98 on element Claim.careTeam.role could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2010EA/PRV/1/03/00/127 on element Claim.careTeam.qualification could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2010F/NM1/1/01/00/98 on element Claim.careTeam.role could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/request/2010F/PRV/1/03/00/127 on element Claim.careTeam.qualification could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/response/2000D/PWK/1/01/00/755 on element CommunicationRequest.category could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/response/2000F/HCR/1/01/00/306 on element Extension.value[x] could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 on element Organization.type could not be resolved',
+    'The valueSet reference https://valueset.x12.org/x217/005010/response/2010EA/NM1/1/01/00/98 on element Extension.extension.value[x] could not be resolved',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CL1/1/01/00/1315 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CL1/1/02/00/1314 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CL1/1/03/00/1352 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000E/CR6/1/01/00/923 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000E/UM/1/01/00/1525 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000E/UM/1/06/00/1338 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000F/HSD/1/07/00/678 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000F/HSD/1/08/00/679 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000F/SV1/1/20/00/1337 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000F/SV2/1/09/00/1345 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000F/UM/1/02/00/1322 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2010A/NM1/1/01/00/98 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/request/2010C/INS/1/08/00/584 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/response/2000D/PWK/1/01/00/755 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/response/2000F/HCR/1/01/00/306 not found',
+    'ValueSet https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 not found',
+    # additional lines added beyond the errors suppressed in the IG
+    'http://hl7.org/fhir/5.0/StructureDefinition/extension-Claim.encounter', # validator bug, https://github.com/hapifhir/org.hl7.fhir.core/issues/1556
+    'X12278DiagnosisCodes', # ValueSet includes full ICD-10-CM plus unavailable code systems; validator cannot fully expand
+    'X12278RequestedServiceType', # X12 code system included in this PAS-defined value set
+    'X12278LocationType', # X12 code system included in this PAS-defined value set
+    'ValueSet https://valueset.x12.org/x217/005010/response/2010B/NM1/1/01/00/98 not found',
+    "Error from http://tx.fhir.org/r4: Error:A definition for the value Set 'http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1' could not be found",
+    "A definition for CodeSystem 'https://www.cms.gov/Medicare/Coding/place-of-service-codes/Place_of_Service_Code_Set' could not be found, so the code cannot be validated",
+    "A definition for CodeSystem 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets' could not be found, so the code cannot be validated",
+    'could not be found, so the code cannot be validated',
+    'https://www.nubc.org/revenue-code',
+    # supress references to draft code systems that the IG references with bindings stronger than example
+    # looks to just be the PAS Temp Codes
+    'Reference to draft CodeSystem http://hl7.org/fhir/us/davinci-pas/CodeSystem/PASTempCodes',
+    # no real content
+    /Details for (.+) matching against profile/,
+    ': All OK',
+    # This was ignored natively in the Inferno validator but needs to be ignored by the test kit with the HL7 validator
+    /URL value '.*' does not resolve/,
+    # addition validator clean-up based on Bundle sub-validations where Inferno error supression doesn't
+    # work. The test kit validates these instances individually as well, so they are still checked,
+    # but in a way that Inferno can supress errors
+    'Unable to find a match for profile',
+    'Unable to find a profile match for',
+    # IG defect: extension context definitions for these extensions don't match where the profiles place them
+    # extension-authorizationNumber context allows Claim.item only, but profile-claim-base marks it must-support on Claim.extension
+    /extension-authorizationNumber( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    /extension-administrationReferenceNumber( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    /extension-communicatedDiagnosis( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    # IG defect: extension-productOrServiceCodeEnd context only lists Claim.item/ClaimResponse, but profile-servicerequest marks it must-support on ServiceRequest
+    /extension-productOrServiceCodeEnd( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    # IG defect: extension-infoChanged and modifierextension-infoCancelled context only lists Claim.item,
+    # but profile-claim-base marks them must-support on Claim.supportingInfo as well
+    /extension-infoChanged( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    /modifierextension-infoCancelled( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    # IG defect: extension-itemAuthorizedProvider context allows ExplanationOfBenefit/ClaimResponse.item only,
+    # but profile-claimresponse marks ClaimResponse.extension:authorizedProvider as must-support on ClaimResponse root
+    /extension-itemAuthorizedProvider( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    # IG defect: extension-revenueUnitRateLimit, extension-serviceItemRequestType, extension-certificationType
+    # context prohibits ClaimResponse.addItem, but profile-claimresponse marks all three as must-support there
+    /extension-revenueUnitRateLimit( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    /extension-serviceItemRequestType( v\d+\.\d+\.\d+)? is not allowed to be used at this point/,
+    /extension-certificationType( v\d+\.\d+\.\d+)? is not allowed to be used at this point/
+  ].freeze
   # rubocop:enable Layout/LineLength
+
+  V221_SUPPRESSED_MESSAGES = Regexp.union(V221_SUPPRESSIONS)
+  V201_SUPPRESSED_MESSAGES = Regexp.union(LEGACY_SUPPRESSIONS + V221_SUPPRESSIONS)
 end

--- a/lib/davinci_pas_test_kit/generator/server_suite_generator.rb
+++ b/lib/davinci_pas_test_kit/generator/server_suite_generator.rb
@@ -57,6 +57,12 @@ module DaVinciPASTestKit
         identifiers.map(&:inspect).join(', ')
       end
 
+      # v2.2+ suites use the targeted suppression list; v2.0.1 keeps the legacy list plus the
+      # targeted entries.
+      def suppressed_messages_constant
+        ig_metadata.ig_version.start_with?('v2.2') ? 'V221_SUPPRESSED_MESSAGES' : 'V201_SUPPRESSED_MESSAGES'
+      end
+
       def ig_link
         case ig_metadata.ig_version
         when 'v2.0.1'

--- a/lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb
+++ b/lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb
@@ -88,8 +88,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, '')) ||
-            message.message.downcase.include?('x12')
+          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb
+++ b/lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb
@@ -88,7 +88,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
+          <%= suppressed_messages_constant %>.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb
@@ -90,8 +90,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, '')) ||
-            message.message.downcase.include?('x12')
+          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb
@@ -90,7 +90,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
+          V201_SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb
@@ -91,8 +91,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, '')) ||
-            message.message.downcase.include?('x12')
+          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb
@@ -91,7 +91,7 @@ module DaVinciPASTestKit
         exclude_message do |message|
           # Messages expected of the form `<ResourceType>: <FHIRPath>: <message>`
           # We strip `<ResourceType>: <FHIRPath>: ` for the sake of matching
-          SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
+          V221_SUPPRESSED_MESSAGES.match?(message.message.sub(/\A\S+: \S+: /, ''))
         end
 
         validation_context do

--- a/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
@@ -56,6 +56,20 @@ RSpec.describe DaVinciPASTestKit do
       'allowed for this version = e:Claim, e:Claim.item)'
   end
 
+  let(:product_or_service_code_end_at_service_request) do
+    'ServiceRequest/ReferralRequestExample: ServiceRequest.extension[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [ServiceRequest]; ' \
+      'allowed for this version = e:Claim.item, e:ClaimResponse)'
+  end
+
+  let(:product_or_service_code_end_at_add_item) do
+    'ClaimResponse/ReferralAuthorizationResponseExample: ClaimResponse.addItem[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-productOrServiceCodeEnd v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [BackboneElement, ClaimResponse.addItem]; ' \
+      'allowed for this version = e:Claim.item, e:ClaimResponse)'
+  end
+
   # Same extensions, but at a genuinely wrong location: these must NOT be suppressed.
   let(:authorization_number_at_wrong_location) do
     'Patient/SubscriberExample: Patient.extension[0]: ' \
@@ -88,9 +102,9 @@ RSpec.describe DaVinciPASTestKit do
       'and a coding from this value set is required'
   end
 
-  # Membership failures against the unexpandable NUBC/X12278 value sets are no longer suppressed:
-  # a correctly configured validator reports code-system-not-found instead, so suppressing the
-  # membership error risks hiding real problems.
+  # NUBC revenue codes are must-support (not required), so the element is empty in the IG examples
+  # but populated by the must support tests; the value set cannot be expanded, so the membership
+  # check is unactionable and is suppressed.
   let(:nubc_value_set_membership_failure) do
     'Claim/ReferralAuthorizationExample: Claim.item[0].revenue: ' \
       "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' " \
@@ -153,6 +167,16 @@ RSpec.describe DaVinciPASTestKit do
         expect(exclude_message.call(validator_message(certification_type_at_add_item, 'error'))).to be true
       end
 
+      it 'excludes productOrServiceCodeEnd at both forced locations (ServiceRequest and addItem)' do
+        expect(exclude_message.call(validator_message(product_or_service_code_end_at_service_request, 'error')))
+          .to be true
+        expect(exclude_message.call(validator_message(product_or_service_code_end_at_add_item, 'error'))).to be true
+      end
+
+      it 'excludes code membership failures against the unexpandable NUBC revenue value set' do
+        expect(exclude_message.call(validator_message(nubc_value_set_membership_failure, 'error'))).to be true
+      end
+
       it 'does not exclude the same extensions when used at a genuinely wrong location' do
         expect(exclude_message.call(validator_message(authorization_number_at_wrong_location, 'error'))).to be false
         expect(exclude_message.call(validator_message(info_changed_at_wrong_location, 'error'))).to be false
@@ -165,10 +189,6 @@ RSpec.describe DaVinciPASTestKit do
 
       it 'does not exclude code membership failures against X12 value sets' do
         expect(exclude_message.call(validator_message(x12_value_set_membership_failure, 'error'))).to be false
-      end
-
-      it 'does not exclude code membership failures against unexpandable value sets' do
-        expect(exclude_message.call(validator_message(nubc_value_set_membership_failure, 'error'))).to be false
       end
 
       it 'does not exclude informational profile-slice-matching messages' do

--- a/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe DaVinciPASTestKit do
       '[PASRequestor])'
   end
 
+  # Some X12 codes are referenced with a valueset.x12.org URL as their code system.
+  let(:x12_code_system_not_found_valueset_url) do
+    'ClaimResponse/ReferralAuthorizationResponseExample: ' \
+      'ClaimResponse.addItem[0].extension[6].value.ofType(CodeableConcept).coding[0].system: ' \
+      "A definition for CodeSystem 'https://valueset.x12.org/x217/005010/response/2000F/NX1/1/01/00/1345' " \
+      'could not be found, so the code cannot be validated'
+  end
+
   # NUBC revenue codes are proprietary; the example data references the code system under both URLs.
   let(:nubc_code_system_not_found) do
     'Claim/ReferralAuthorizationExample: Claim.item[0].revenue.coding[0]: ' \
@@ -151,8 +159,9 @@ RSpec.describe DaVinciPASTestKit do
         end
       end
 
-      it 'excludes unresolvable X12 code system messages' do
+      it 'excludes unresolvable X12 code system messages under either x12.org subdomain' do
         expect(exclude_message.call(validator_message(x12_code_system_not_found, 'warning'))).to be true
+        expect(exclude_message.call(validator_message(x12_code_system_not_found_valueset_url, 'warning'))).to be true
       end
 
       it 'excludes unresolvable NUBC revenue code system messages under either code system URL' do
@@ -215,6 +224,7 @@ RSpec.describe DaVinciPASTestKit do
           expect(exclude_message.call(validator_message(x12_value_set_not_found, type))).to be true
         end
         expect(exclude_message.call(validator_message(x12_code_system_not_found, 'warning'))).to be true
+        expect(exclude_message.call(validator_message(x12_code_system_not_found_valueset_url, 'warning'))).to be true
       end
 
       it 'still excludes legacy suppression patterns' do

--- a/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe DaVinciPASTestKit do
+  let(:x12_value_set_not_found) do
+    'Claim/ReferralAuthorizationExample: Claim.extension[0].value.ofType(CodeableConcept): ' \
+      "ValueSet 'https://valueset.x12.org/x217/005010/request/2000E/UM/1/06/00/1338' not found " \
+      '(validating against http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claim|2.2.1 [PASClaim])'
+  end
+
+  let(:x12_code_system_not_found) do
+    'Organization/UMOExample: Organization.type[0].coding[0]: ' \
+      "A definition for CodeSystem 'https://codesystem.x12.org/005010/98' could not be found, " \
+      'so the code cannot be validated ' \
+      '(validating against http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-requestor|2.2.1 ' \
+      '[PASRequestor])'
+  end
+
+  let(:non_x12_value_set_not_found) do
+    'Patient/SubscriberExample: Patient.communication[0].language: ' \
+      "ValueSet 'http://hl7.org/fhir/us/core/ValueSet/simple-language' not found"
+  end
+
+  let(:x12_code_not_in_value_set) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0].category: ' \
+      'None of the codings provided are in the value set ' \
+      "'https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365', " \
+      'and a coding from this value set is required'
+  end
+
+  [
+    DaVinciPASTestKit::DaVinciPASV201::ServerSuite,
+    DaVinciPASTestKit::DaVinciPASV221::ServerSuite,
+    DaVinciPASTestKit::DaVinciPASV201::ClientSuite,
+    DaVinciPASTestKit::DaVinciPASV221::ClientSuite
+  ].each do |suite|
+    describe "#{suite.title} validator message exclusions" do
+      let(:exclude_message) { suite.fhir_validators[:default].first.exclude_message }
+
+      def validator_message(text, type)
+        Inferno::Entities::Message.new(type:, message: text)
+      end
+
+      it 'excludes unresolvable X12 value set messages at every severity' do
+        %w[error warning info].each do |type|
+          expect(exclude_message.call(validator_message(x12_value_set_not_found, type))).to be true
+        end
+      end
+
+      it 'excludes unresolvable X12 code system messages' do
+        expect(exclude_message.call(validator_message(x12_code_system_not_found, 'warning'))).to be true
+      end
+
+      it 'does not exclude resolution failures for non-X12 value sets' do
+        expect(exclude_message.call(validator_message(non_x12_value_set_not_found, 'warning'))).to be false
+      end
+
+      it 'does not exclude code membership failures against X12 value sets' do
+        expect(exclude_message.call(validator_message(x12_code_not_in_value_set, 'error'))).to be false
+      end
+    end
+  end
+end

--- a/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
@@ -120,6 +120,21 @@ RSpec.describe DaVinciPASTestKit do
       'is required'
   end
 
+  # Other PAS-defined value sets whose members are entirely X12 codes; membership is unactionable.
+  let(:pwk01_value_set_membership_failure) do
+    'DocumentReference/DocumentReferenceExample: DocumentReference.type: ' \
+      "None of the codings provided are in the value set 'PAS PWK01 Attachment Report Type Code Value Set' " \
+      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/pas-pwk01-attachment-report-type-code|2.2.1), and a coding ' \
+      'should come from this value set'
+  end
+
+  let(:communication_medium_value_set_membership_failure) do
+    'CommunicationRequest/CommunicationRequestExample: CommunicationRequest.medium[0]: ' \
+      "None of the codings provided are in the value set 'PAS Communication Medium Value Set' " \
+      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/PASCommunicationRequestMedium|2.2.1), and a coding from this ' \
+      'value set is required'
+  end
+
   let(:details_for_matching_profile) do
     'Bundle/ReferralAuthorizationBundleExample: Bundle.entry[0]: ' \
       'Details for Claim/ReferralAuthorizationExample matching against profile ' \
@@ -184,6 +199,12 @@ RSpec.describe DaVinciPASTestKit do
 
       it 'excludes code membership failures against the unexpandable NUBC revenue value set' do
         expect(exclude_message.call(validator_message(nubc_value_set_membership_failure, 'error'))).to be true
+      end
+
+      it 'excludes code membership failures against all-X12 PAS-defined value sets' do
+        expect(exclude_message.call(validator_message(pwk01_value_set_membership_failure, 'warning'))).to be true
+        expect(exclude_message.call(validator_message(communication_medium_value_set_membership_failure, 'error')))
+          .to be true
       end
 
       it 'does not exclude the same extensions when used at a genuinely wrong location' do

--- a/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
@@ -13,30 +13,76 @@ RSpec.describe DaVinciPASTestKit do
       '[PASRequestor])'
   end
 
+  let(:nubc_code_system_not_found) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0].revenue.coding[0]: ' \
+      "A definition for CodeSystem 'https://www.nubc.org/revenue-code' could not be found, " \
+      'so the code cannot be validated'
+  end
+
+  let(:nubc_value_set_membership_failure) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0].revenue: ' \
+      "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' " \
+      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes|2.2.1), and a coding from this value set ' \
+      'is required) (codes = https://www.nubc.org/revenue-code#0105)'
+  end
+
+  let(:x12278_value_set_membership_failure) do
+    'Claim/HomecareAuthorizationExample: Claim.item[0].productOrService: ' \
+      "None of the codings provided are in the value set 'X12 278 Requested Service Type' " \
+      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/X12278RequestedServiceType|2.2.1), and a coding from this ' \
+      'value set is required)'
+  end
+
+  let(:extension_context_error) do
+    'Claim/ReferralAuthorizationExample: Claim.supportingInfo[2]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-infoChanged v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [Backbone Element: Claim.supportingInfo])'
+  end
+
+  let(:modifier_extension_context_error) do
+    'Claim/ReferralAuthorizationExample: Claim.supportingInfo[2]: ' \
+      'The modifier extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/' \
+      'modifierextension-infoCancelled v2.2.1 is not allowed to be used at this point'
+  end
+
   let(:non_x12_value_set_not_found) do
     'Patient/SubscriberExample: Patient.communication[0].language: ' \
       "ValueSet 'http://hl7.org/fhir/us/core/ValueSet/simple-language' not found"
   end
 
-  let(:x12_code_not_in_value_set) do
+  let(:x12_value_set_membership_failure) do
     'Claim/ReferralAuthorizationExample: Claim.item[0].category: ' \
       'None of the codings provided are in the value set ' \
       "'https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365', " \
       'and a coding from this value set is required'
   end
 
+  let(:hcpcs_code_system_not_found) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0].productOrService.coding[0]: ' \
+      "A definition for CodeSystem 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets' " \
+      'could not be found, so the code cannot be validated'
+  end
+
+  let(:profile_match_error) do
+    'Bundle/ReferralAuthorizationBundleExample: Bundle.entry[3]: ' \
+      'Unable to find a profile match for Coverage/InsuranceExample among choices: ' \
+      'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-coverage|2.2.1'
+  end
+
+  let(:all_ok_message) do
+    'Bundle.entry[0].resource.ofType(Claim): All OK'
+  end
+
+  def validator_message(text, type)
+    Inferno::Entities::Message.new(type:, message: text)
+  end
+
   [
-    DaVinciPASTestKit::DaVinciPASV201::ServerSuite,
     DaVinciPASTestKit::DaVinciPASV221::ServerSuite,
-    DaVinciPASTestKit::DaVinciPASV201::ClientSuite,
     DaVinciPASTestKit::DaVinciPASV221::ClientSuite
   ].each do |suite|
     describe "#{suite.title} validator message exclusions" do
       let(:exclude_message) { suite.fhir_validators[:default].first.exclude_message }
-
-      def validator_message(text, type)
-        Inferno::Entities::Message.new(type:, message: text)
-      end
 
       it 'excludes unresolvable X12 value set messages at every severity' do
         %w[error warning info].each do |type|
@@ -48,12 +94,61 @@ RSpec.describe DaVinciPASTestKit do
         expect(exclude_message.call(validator_message(x12_code_system_not_found, 'warning'))).to be true
       end
 
+      it 'excludes unresolvable NUBC revenue code system messages' do
+        expect(exclude_message.call(validator_message(nubc_code_system_not_found, 'warning'))).to be true
+      end
+
+      it 'excludes code membership failures against the unexpandable NUBC revenue value set' do
+        expect(exclude_message.call(validator_message(nubc_value_set_membership_failure, 'error'))).to be true
+      end
+
+      it 'excludes code membership failures against the unexpandable X12278RequestedServiceType value set' do
+        expect(exclude_message.call(validator_message(x12278_value_set_membership_failure, 'error'))).to be true
+      end
+
+      it 'excludes extension context errors caused by IG defects' do
+        expect(exclude_message.call(validator_message(extension_context_error, 'error'))).to be true
+        expect(exclude_message.call(validator_message(modifier_extension_context_error, 'error'))).to be true
+      end
+
       it 'does not exclude resolution failures for non-X12 value sets' do
         expect(exclude_message.call(validator_message(non_x12_value_set_not_found, 'warning'))).to be false
       end
 
       it 'does not exclude code membership failures against X12 value sets' do
-        expect(exclude_message.call(validator_message(x12_code_not_in_value_set, 'error'))).to be false
+        expect(exclude_message.call(validator_message(x12_value_set_membership_failure, 'error'))).to be false
+      end
+
+      it 'does not exclude legacy-only patterns dropped from the targeted list' do
+        expect(exclude_message.call(validator_message(hcpcs_code_system_not_found, 'warning'))).to be false
+        expect(exclude_message.call(validator_message(profile_match_error, 'error'))).to be false
+        expect(exclude_message.call(validator_message(all_ok_message, 'info'))).to be false
+      end
+    end
+  end
+
+  [
+    DaVinciPASTestKit::DaVinciPASV201::ServerSuite,
+    DaVinciPASTestKit::DaVinciPASV201::ClientSuite
+  ].each do |suite|
+    describe "#{suite.title} validator message exclusions" do
+      let(:exclude_message) { suite.fhir_validators[:default].first.exclude_message }
+
+      it 'excludes the targeted X12 patterns at every severity' do
+        %w[error warning info].each do |type|
+          expect(exclude_message.call(validator_message(x12_value_set_not_found, type))).to be true
+        end
+        expect(exclude_message.call(validator_message(x12_code_system_not_found, 'warning'))).to be true
+      end
+
+      it 'still excludes legacy suppression patterns' do
+        expect(exclude_message.call(validator_message(hcpcs_code_system_not_found, 'warning'))).to be true
+        expect(exclude_message.call(validator_message(profile_match_error, 'error'))).to be true
+        expect(exclude_message.call(validator_message(all_ok_message, 'info'))).to be true
+      end
+
+      it 'does not exclude resolution failures for non-X12 value sets' do
+        expect(exclude_message.call(validator_message(non_x12_value_set_not_found, 'warning'))).to be false
       end
     end
   end

--- a/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb
@@ -13,36 +13,67 @@ RSpec.describe DaVinciPASTestKit do
       '[PASRequestor])'
   end
 
+  # NUBC revenue codes are proprietary; the example data references the code system under both URLs.
   let(:nubc_code_system_not_found) do
     'Claim/ReferralAuthorizationExample: Claim.item[0].revenue.coding[0]: ' \
       "A definition for CodeSystem 'https://www.nubc.org/revenue-code' could not be found, " \
       'so the code cannot be validated'
   end
 
-  let(:nubc_value_set_membership_failure) do
-    'Claim/ReferralAuthorizationExample: Claim.item[0].revenue: ' \
-      "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' " \
-      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes|2.2.1), and a coding from this value set ' \
-      'is required) (codes = https://www.nubc.org/revenue-code#0105)'
+  let(:nubc_code_system_not_found_alt_url) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0].revenue.coding[0]: ' \
+      "A definition for CodeSystem 'https://www.nubc.org/CodeSystem/RevenueCodes' could not be found, " \
+      'so the code cannot be validated'
   end
 
-  let(:x12278_value_set_membership_failure) do
-    'Claim/HomecareAuthorizationExample: Claim.item[0].productOrService: ' \
-      "None of the codings provided are in the value set 'X12 278 Requested Service Type' " \
-      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/X12278RequestedServiceType|2.2.1), and a coding from this ' \
-      'value set is required)'
+  # Extension-placement errors carry the element context in the message as "(this element is [...])".
+  # Each fixture below uses the exact context the IG defect forces.
+  let(:authorization_number_at_claim) do
+    'Claim/ReferralAuthorizationExample: Claim.extension[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-authorizationNumber v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [Claim]; ' \
+      'allowed for this version = e:Claim.item, e:ClaimResponse.item)'
   end
 
-  let(:extension_context_error) do
+  let(:info_changed_at_supporting_info) do
     'Claim/ReferralAuthorizationExample: Claim.supportingInfo[2]: ' \
       'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-infoChanged v2.2.1 ' \
-      'is not allowed to be used at this point (this element is [Backbone Element: Claim.supportingInfo])'
+      'is not allowed to be used at this point (this element is [BackboneElement, Claim.supportingInfo]; ' \
+      'allowed for this version = e:Claim.item)'
   end
 
-  let(:modifier_extension_context_error) do
+  let(:info_cancelled_at_supporting_info) do
     'Claim/ReferralAuthorizationExample: Claim.supportingInfo[2]: ' \
       'The modifier extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/' \
-      'modifierextension-infoCancelled v2.2.1 is not allowed to be used at this point'
+      'modifierextension-infoCancelled v2.2.1 is not allowed to be used at this point ' \
+      '(this element is [BackboneElement, Claim.supportingInfo]; allowed = e:Claim.item)'
+  end
+
+  let(:certification_type_at_add_item) do
+    'ClaimResponse/ReferralAuthorizationResponseExample: ClaimResponse.addItem[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-certificationType v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [BackboneElement, ClaimResponse.addItem]; ' \
+      'allowed for this version = e:Claim, e:Claim.item)'
+  end
+
+  # Same extensions, but at a genuinely wrong location: these must NOT be suppressed.
+  let(:authorization_number_at_wrong_location) do
+    'Patient/SubscriberExample: Patient.extension[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-authorizationNumber v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [Patient]; ' \
+      'allowed for this version = e:Claim.item)'
+  end
+
+  let(:info_changed_at_wrong_location) do
+    'Claim/ReferralAuthorizationExample: Claim.extension[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-infoChanged v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [Claim]; allowed for this version = e:Claim.item)'
+  end
+
+  let(:certification_type_at_wrong_location) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0]: ' \
+      'The extension http://hl7.org/fhir/us/davinci-pas/StructureDefinition/extension-certificationType v2.2.1 ' \
+      'is not allowed to be used at this point (this element is [BackboneElement, Claim.item]; allowed = e:Claim)'
   end
 
   let(:non_x12_value_set_not_found) do
@@ -55,6 +86,22 @@ RSpec.describe DaVinciPASTestKit do
       'None of the codings provided are in the value set ' \
       "'https://valueset.x12.org/x217/005010/request/2000F/UM/1/03/00/1365', " \
       'and a coding from this value set is required'
+  end
+
+  # Membership failures against the unexpandable NUBC/X12278 value sets are no longer suppressed:
+  # a correctly configured validator reports code-system-not-found instead, so suppressing the
+  # membership error risks hiding real problems.
+  let(:nubc_value_set_membership_failure) do
+    'Claim/ReferralAuthorizationExample: Claim.item[0].revenue: ' \
+      "None of the codings provided are in the value set 'AHA NUBC Revenue Value Set' " \
+      '(http://hl7.org/fhir/us/davinci-pas/ValueSet/AHANUBCRevenueCodes|2.2.1), and a coding from this value set ' \
+      'is required'
+  end
+
+  let(:details_for_matching_profile) do
+    'Bundle/ReferralAuthorizationBundleExample: Bundle.entry[0]: ' \
+      'Details for Claim/ReferralAuthorizationExample matching against profile ' \
+      'http://hl7.org/fhir/us/davinci-pas/StructureDefinition/profile-claim|2.2.1'
   end
 
   let(:hcpcs_code_system_not_found) do
@@ -94,21 +141,22 @@ RSpec.describe DaVinciPASTestKit do
         expect(exclude_message.call(validator_message(x12_code_system_not_found, 'warning'))).to be true
       end
 
-      it 'excludes unresolvable NUBC revenue code system messages' do
+      it 'excludes unresolvable NUBC revenue code system messages under either code system URL' do
         expect(exclude_message.call(validator_message(nubc_code_system_not_found, 'warning'))).to be true
+        expect(exclude_message.call(validator_message(nubc_code_system_not_found_alt_url, 'warning'))).to be true
       end
 
-      it 'excludes code membership failures against the unexpandable NUBC revenue value set' do
-        expect(exclude_message.call(validator_message(nubc_value_set_membership_failure, 'error'))).to be true
+      it 'excludes IG-defect extension placement errors at the specific forced location' do
+        expect(exclude_message.call(validator_message(authorization_number_at_claim, 'error'))).to be true
+        expect(exclude_message.call(validator_message(info_changed_at_supporting_info, 'error'))).to be true
+        expect(exclude_message.call(validator_message(info_cancelled_at_supporting_info, 'error'))).to be true
+        expect(exclude_message.call(validator_message(certification_type_at_add_item, 'error'))).to be true
       end
 
-      it 'excludes code membership failures against the unexpandable X12278RequestedServiceType value set' do
-        expect(exclude_message.call(validator_message(x12278_value_set_membership_failure, 'error'))).to be true
-      end
-
-      it 'excludes extension context errors caused by IG defects' do
-        expect(exclude_message.call(validator_message(extension_context_error, 'error'))).to be true
-        expect(exclude_message.call(validator_message(modifier_extension_context_error, 'error'))).to be true
+      it 'does not exclude the same extensions when used at a genuinely wrong location' do
+        expect(exclude_message.call(validator_message(authorization_number_at_wrong_location, 'error'))).to be false
+        expect(exclude_message.call(validator_message(info_changed_at_wrong_location, 'error'))).to be false
+        expect(exclude_message.call(validator_message(certification_type_at_wrong_location, 'error'))).to be false
       end
 
       it 'does not exclude resolution failures for non-X12 value sets' do
@@ -117,6 +165,14 @@ RSpec.describe DaVinciPASTestKit do
 
       it 'does not exclude code membership failures against X12 value sets' do
         expect(exclude_message.call(validator_message(x12_value_set_membership_failure, 'error'))).to be false
+      end
+
+      it 'does not exclude code membership failures against unexpandable value sets' do
+        expect(exclude_message.call(validator_message(nubc_value_set_membership_failure, 'error'))).to be false
+      end
+
+      it 'does not exclude informational profile-slice-matching messages' do
+        expect(exclude_message.call(validator_message(details_for_matching_profile, 'info'))).to be false
       end
 
       it 'does not exclude legacy-only patterns dropped from the targeted list' do
@@ -145,6 +201,14 @@ RSpec.describe DaVinciPASTestKit do
         expect(exclude_message.call(validator_message(hcpcs_code_system_not_found, 'warning'))).to be true
         expect(exclude_message.call(validator_message(profile_match_error, 'error'))).to be true
         expect(exclude_message.call(validator_message(all_ok_message, 'info'))).to be true
+      end
+
+      # The v2.0.1 list keeps the original location-blind extension suppressions, so it still
+      # excludes these placement errors regardless of where the extension was seen. The location
+      # anchoring only applies to the v2.2.1 list.
+      it 'excludes extension placement errors regardless of location' do
+        expect(exclude_message.call(validator_message(authorization_number_at_claim, 'error'))).to be true
+        expect(exclude_message.call(validator_message(authorization_number_at_wrong_location, 'error'))).to be true
       end
 
       it 'does not exclude resolution failures for non-X12 value sets' do


### PR DESCRIPTION
## Summary

The PAS IG binds many elements to proprietary X12 value sets whose definitions are not available to the terminology server. The server suites carried a broad filter that suppressed any validator message containing "x12" at any severity, while the client suites had no x12 filtering at all, so unresolvable x12 value set warnings surfaced in client suite results.

Investigation against the current validator (wrapper 1.0.79, validator core 6.9.11), using the IG's own example bundles, showed that x12 messages now come in exactly two shapes, both at warning severity with no errors remaining:

- `ValueSet 'https://valueset.x12.org/...' not found`
- `A definition for CodeSystem 'https://codesystem.x12.org/...' could not be found, so the code cannot be validated`

The exact-string `ValueSet <url> not found` entries already present in `SUPPRESSED_MESSAGES` (copied from the IG's published suppression list) stopped matching because newer validator versions quote the URL, which is why the warnings became visible in the client suites. The CodeSystem shape is still caught by the existing generic "could not be found, so the code cannot be validated" entry.

### What changed

- `lib/davinci_pas_test_kit/cross_suite/validator_suppressions.rb` - added a narrow regex, `%r{ValueSet 'https://valueset\.x12\.org/[^']+' not found}`, to the shared `SUPPRESSED_MESSAGES` constant. Since all four suites apply this constant in their `exclude_message` blocks, the suppression now applies consistently to client and server suites at every severity (the exclusion logic matches on message text only).
- `lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb`, `lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb`, and `lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb` - removed the broad `message.message.downcase.include?('x12')` clause. The server exclusion logic is now identical to the client suites.

Net behavior: resolution failures for X12 value sets and code systems remain suppressed everywhere, while actionable messages that merely mention an x12 URL (for example, a code-not-in-value-set finding) are no longer swallowed. Replaying recorded validator responses for the IG example bundles through the old and new logic produced identical classification for every real message, so there is no user-visible regression from the narrowing.

The suite and test descriptions already note that elements bound to X12 value sets are not validated, so no description changes were needed.

### Spec coverage

New spec `spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb` exercises the actual `exclude_message` proc registered by each of the four suites (16 examples):

| Case | Expected |
| --- | --- |
| x12 `ValueSet '<url>' not found` (real message text) at error, warning, and info severity | excluded |
| x12 `A definition for CodeSystem '<url>' could not be found...` | excluded |
| Non-x12 `ValueSet '<url>' not found` (US Core URL) | not excluded |
| Code membership failure referencing an x12 value set URL | not excluded |

### Testing

- `bundle exec rspec` - 391 examples, 0 failures.
- `bundle exec rubocop` - no offenses.
- Manual UI verification via the loopback presets (steps below).

---

## UI Testing Steps

These steps follow [docs/Running-Suites-Against-Each-Other.md](https://github.com/inferno-framework/davinci-pas-test-kit/blob/support-v2.2.0/docs/Running-Suites-Against-Each-Other.md) ("Basic Execution (v2.2.1)").

### Setup

Start Inferno (`./run.sh`), open the UI at `http://localhost:4567`, and open two browser windows.

Client Suite window:

1. Choose "Da Vinci PAS Client Suite v2.2.1" with the "Other Authentication" client security type and click "Start Testing".
2. From the Preset dropdown, select "Run Against the PAS Server Suite".

Server Suite window:

1. Choose "Da Vinci PAS Server Suite v2.2.1" and click "Start Testing".
2. From the Preset dropdown, select "Run Against the PAS Client Suite".

### Execution

Run the paired groups in order per the doc, submitting the pre-filled preset inputs and responding to the "User Action Required" dialogs as described there:

1. Client group 1 (Client Registration), then client group 10 plus server group 1 (Subscription Setup).
2. Client 11.1 with server 2.1 (Approval Workflow).
3. Client 11.2 with server 2.2 (Denial Workflow).
4. Client 11.3 with server 2.3 (Pended Workflow).
5. Client 11.4 with server 2.4 (Claim Updates).
6. Client 12 with server 3 (Must Support Elements).
7. Client 13.1 with server 4 (Operation Failure).

### Where to verify the results

The change is visible in the Messages tab of the Bundle validation tests:

- Client suite: expand any "... Bundle is valid" test under groups 11.1 through 11.4 (for example, 11.4.2.01 "Initial submission: submit request Bundle is valid") and open the MESSAGES tab. Before this change, this tab listed multiple warnings of the form `ValueSet 'https://valueset.x12.org/...' not found`. After this change, those warnings are gone.
- Server suite: open the request and response Bundle validation tests inside groups 2.1 through 2.4 and group 3 and check the MESSAGES tab the same way. These were already free of x12 messages under the old broad filter and must remain so.
- Confirm the filter is not over-broad: unrelated messages (for example, "Example URLs are not allowed in this context" and other non-x12 warnings produced by the preset payloads) must still appear in the same tabs.

### Test IDs

Automated:

- `spec/davinci_pas_test_kit/cross_suite/validator_suppressions_spec.rb` (new, 16 examples)
- Full suite: `bundle exec rspec`