### PR TITLE
ID-165: Error handling and cleanup for must support response selection

### DIFF
--- a/lib/davinci_pas_test_kit/client/abstract_gather_must_support_test.rb
+++ b/lib/davinci_pas_test_kit/client/abstract_gather_must_support_test.rb
@@ -43,58 +43,12 @@ module DaVinciPASTestKit
           title: 'Must Support $submit Response Bundles',
           type: 'textarea',
           optional: true,
-          description: %(
-            An optional JSON value specifying response Bundles for Inferno to return when
-            responding to $submit requests during must support testing. Provide a single entry
-            or a list of entries, where each entry is either a FHIR Bundle or a wrapper object
-            of the form `{"criteria": {...}, "bundle": {...}}` pairing a FHIR Bundle with the
-            selection criteria that a request must meet for that Bundle to be returned.
-
-            For each request, Inferno will respond with the Bundle of the first entry whose
-            criteria are all met. An entry with no criteria (including a bare Bundle) matches
-            any request, and an entry with multiple criteria must meet all of them. If no entry
-            matches, or none are provided, Inferno will generate a default response. Supported
-            `criteria` keys:
-
-            - `requestRange`: a string of comma-separated request numbers or ranges, e.g.,
-              `"1-2,4"`. Met when the number of $submit requests received during this test,
-              counting this one, is among the listed values.
-            - `fhirpath`: a FHIRPath expression evaluated against the incoming request Bundle.
-              Met when the expression evaluates to a single truthy value.
-
-            A Bundle may also contain tokens of the form `{{fhirpath}}`, e.g.,
-            `{{Bundle.entry.first().resource.id}}`. Inferno replaces each token in the returned
-            Bundle with the result of evaluating the FHIRPath expression against the incoming
-            request Bundle.
-          )
+          description: DaVinciPASTestKit.ms_responses_input_description('$submit')
     input :ms_inquire_responses,
           title: 'Must Support $inquire Response Bundles',
           type: 'textarea',
           optional: true,
-          description: %(
-            An optional JSON value specifying response Bundles for Inferno to return when
-            responding to $inquire requests during must support testing. Provide a single entry
-            or a list of entries, where each entry is either a FHIR Bundle or a wrapper object
-            of the form `{"criteria": {...}, "bundle": {...}}` pairing a FHIR Bundle with the
-            selection criteria that a request must meet for that Bundle to be returned.
-
-            For each request, Inferno will respond with the Bundle of the first entry whose
-            criteria are all met. An entry with no criteria (including a bare Bundle) matches
-            any request, and an entry with multiple criteria must meet all of them. If no entry
-            matches, or none are provided, Inferno will generate a default response. Supported
-            `criteria` keys:
-
-            - `requestRange`: a string of comma-separated request numbers or ranges, e.g.,
-              `"1-2,4"`. Met when the number of $inquire requests received during this test,
-              counting this one, is among the listed values.
-            - `fhirpath`: a FHIRPath expression evaluated against the incoming request Bundle.
-              Met when the expression evaluates to a single truthy value.
-
-            A Bundle may also contain tokens of the form `{{fhirpath}}`, e.g.,
-            `{{Bundle.entry.first().resource.id}}`. Inferno replaces each token in the returned
-            Bundle with the result of evaluating the FHIRPath expression against the incoming
-            request Bundle.
-          )
+          description: DaVinciPASTestKit.ms_responses_input_description('$inquire')
     config options: { accepts_multiple_requests: true }
     output :confirmation_url
 

--- a/lib/davinci_pas_test_kit/client/client_input_descriptions.rb
+++ b/lib/davinci_pas_test_kit/client/client_input_descriptions.rb
@@ -7,4 +7,33 @@ module DaVinciPASTestKit
   INPUT_SESSION_URL_PATH_LOCKED =
     'The additional path used to create session-specific endpoints. Run the ' \
     '**1** Client Registration group to configure this input.'
+
+  # Shared documentation for the must support response inputs, which differ only
+  # in the operation whose responses they configure ('$submit' or '$inquire').
+  def self.ms_responses_input_description(operation)
+    <<~DESCRIPTION
+      An optional JSON value specifying response Bundles for Inferno to return when
+      responding to #{operation} requests during must support testing. Provide a single entry
+      or a list of entries, where each entry is either a FHIR Bundle or a wrapper object
+      of the form `{"criteria": {...}, "bundle": {...}}` pairing a FHIR Bundle with the
+      selection criteria that a request must meet for that Bundle to be returned.
+
+      For each request, Inferno will respond with the Bundle of the first entry whose
+      criteria are all met. An entry with no criteria (including a bare Bundle) matches
+      any request, and an entry with multiple criteria must meet all of them. If no entry
+      matches, or none are provided, Inferno will generate a default response. Supported
+      `criteria` keys:
+
+      - `requestRange`: a string of comma-separated request numbers or ranges, e.g.,
+        `"1-2,4"`. Met when the number of #{operation} requests received during this test,
+        counting this one, is among the listed values.
+      - `fhirpath`: a FHIRPath expression evaluated against the incoming request Bundle.
+        Met when the expression evaluates to a single truthy value.
+
+      A Bundle may also contain tokens of the form `{{fhirpath}}`, e.g.,
+      `{{Bundle.entry.first().resource.id}}`. Inferno replaces each token in the returned
+      Bundle with the result of evaluating the FHIRPath expression against the incoming
+      request Bundle.
+    DESCRIPTION
+  end
 end

--- a/lib/davinci_pas_test_kit/client/endpoints/claim_endpoint.rb
+++ b/lib/davinci_pas_test_kit/client/endpoints/claim_endpoint.rb
@@ -165,14 +165,15 @@ module DaVinciPASTestKit
     # match the incoming request, extracts its response Bundle (unwrapping it when the
     # candidate pairs the Bundle with criteria), and replaces {{fhirpath}} tokens with
     # values from the request. Returns nil, causing Inferno to generate a default
-    # response, if no candidates are provided or none match.
+    # response, if no candidates are provided, none match, or the FHIRPath service
+    # cannot evaluate criteria or tokens.
     def select_must_support_response(req_bundle)
       candidates = UserInputResponse.response_candidates(result, operation)
       return if candidates.blank?
 
       operation_url_suffix = "$#{operation}"
       request_number = count_previous_successful_requests(operation_url_suffix) + 1
-      selected_index = candidates.index { |candidate| include_entity?(candidate, req_bundle, operation_url_suffix) }
+      selected_index = candidates.index { |candidate| include_entity?(candidate, req_bundle, request_number) }
 
       if selected_index.nil?
         Inferno::Application['logger'].info(
@@ -187,16 +188,22 @@ module DaVinciPASTestKit
         "for #{operation_url_suffix} request ##{request_number}."
       )
       replace_tokens(entity_bundle(candidates[selected_index]), req_bundle)
+    rescue FhirpathUtils::FhirpathServiceError, Faraday::Error => e
+      Inferno::Application['logger'].warn(
+        "Unable to select a tester-provided response (#{e.message}). Inferno will generate a default response."
+      )
+      nil
     end
 
-    # Round-trips the selected bundle through the FHIR model to normalize it after
-    # token replacement. Falls back to the replaced string if it no longer parses,
-    # e.g., when a replaced value breaks the JSON structure.
+    # Replaces {{fhirpath}} tokens using values from the incoming request, round-tripping
+    # the result through the FHIR model to normalize it. Falls back to the replaced string
+    # if it no longer parses, e.g., when a replaced value breaks the JSON structure.
     def replace_tokens(bundle_hash, req_bundle)
-      replaced = replace_tokens_in_string(bundle_hash.to_json, req_bundle)
+      bundle_json = bundle_hash.to_json
+      replaced = replace_tokens_in_string(bundle_json, req_bundle)
+      return bundle_json if replaced.equal?(bundle_json)
+
       FHIR.from_contents(replaced)&.to_json || replaced
-    rescue JSON::ParserError
-      replaced
     end
 
     def handle_missing_required_elements(claim_entry, response)
@@ -255,7 +262,8 @@ module DaVinciPASTestKit
     end
 
     def operation
-      request.url&.split('$')&.last
+      operation_with_query = request.url&.split('$')&.last
+      operation_with_query&.split('?')&.first
     end
 
     def start_notification_job(response_bundle_json, decision, generated_claim_response_uuid)

--- a/lib/davinci_pas_test_kit/client/user_input_response.rb
+++ b/lib/davinci_pas_test_kit/client/user_input_response.rb
@@ -24,7 +24,8 @@ module DaVinciPASTestKit
     # JSON array of entries, where each entry is either a bare FHIR Bundle or a
     # wrapper object holding the response Bundle under "bundle" alongside optional
     # selection "criteria".
-    # Returns nil if the input is not present, not parseable, or malformed.
+    # Returns nil, with a log entry when the value is present but unusable, so that
+    # Inferno falls back to generated default responses.
     def self.response_candidates(result, operation)
       input_name = operation == 'submit' ? 'ms_submit_responses' : 'ms_inquire_responses'
       input_value = JSON.parse(result.input_json)&.find { |i| i['name'] == input_name }&.dig('value')
@@ -32,8 +33,20 @@ module DaVinciPASTestKit
 
       candidates = JSON.parse(input_value)
       candidates = [candidates] unless candidates.is_a?(Array)
-      candidates if candidates.all? { |candidate| valid_candidate?(candidate) }
+      invalid_index = candidates.index { |candidate| !valid_candidate?(candidate) }
+      if invalid_index.present?
+        Inferno::Application['logger'].warn(
+          "Ignoring the '#{input_name}' input: entry #{invalid_index + 1} is neither a FHIR Bundle nor a " \
+          'wrapper object with a "bundle" key. Inferno will generate default responses.'
+        )
+        return
+      end
+
+      candidates
     rescue JSON::ParserError
+      Inferno::Application['logger'].warn(
+        "Ignoring the '#{input_name}' input because it is not valid JSON. Inferno will generate default responses."
+      )
       nil
     end
 

--- a/lib/davinci_pas_test_kit/cross_suite/fhirpath_utils.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/fhirpath_utils.rb
@@ -14,8 +14,7 @@ module DaVinciPASTestKit
       return fhirpath_result if fhirpath_result.status.to_s.start_with?('2')
 
       raise FhirpathServiceError,
-            "FHIRPath service returned #{fhirpath_result.status} for query '#{query}' " \
-            "on resource #{body}: #{fhirpath_result.body}"
+            "FHIRPath service returned #{fhirpath_result.status} for query '#{query}'"
     end
 
     def interpret_fhirpath_result_as_boolean(fhirpath_result)
@@ -50,6 +49,8 @@ module DaVinciPASTestKit
         .map { |element| element.is_a?(Array) || element.is_a?(Hash) ? nil : element }
         .compact
         .join(',')
+    rescue JSON::ParserError
+      raise FhirpathServiceError, "FHIRPath service returned an unparseable body for query '#{expression}'"
     end
   end
 end

--- a/lib/davinci_pas_test_kit/cross_suite/response_selection_utils.rb
+++ b/lib/davinci_pas_test_kit/cross_suite/response_selection_utils.rb
@@ -32,10 +32,10 @@ module DaVinciPASTestKit
       criteria.is_a?(Hash) ? criteria : {}
     end
 
-    def include_entity?(entity, request_fhir_obj, operation)
+    def include_entity?(entity, request_fhir_obj, request_number)
       criteria = entity_criteria(entity)
       return false if criteria[REQUEST_RANGE_KEY].present? &&
-                      !request_meets_request_range_criteria?(criteria[REQUEST_RANGE_KEY], operation)
+                      !ranges_cover_value?(request_number, criteria[REQUEST_RANGE_KEY].to_s)
       return false if criteria[FHIRPATH_KEY].present? &&
                       !request_meets_inclusion_criteria?(criteria[FHIRPATH_KEY], request_fhir_obj)
 
@@ -55,16 +55,14 @@ module DaVinciPASTestKit
     # Request index-based selection criteria
     # ***********************************************************************
 
-    def request_meets_request_range_criteria?(ranges, operation)
-      ranges_cover_value?(count_previous_successful_requests(operation) + 1, ranges.to_s)
-    end
-
     def count_previous_successful_requests(operation)
       requests_repo = Inferno::Repositories::Requests.new
       previous_requests = requests_repo.requests_for_result(result.id)
       previous_requests.count { |req| req.url.include?(operation) && req.status == 200 }
     end
 
+    # An invalid range comes from tester input, so it is logged and treated as unmet
+    # rather than raised, leaving the candidate unselected.
     def ranges_cover_value?(value, ranges_string)
       unless /\A(\d+(-\d+)?,)*\d+(-\d+)?\z/.match?(ranges_string)
         raise ArgumentError,
@@ -82,7 +80,8 @@ module DaVinciPASTestKit
         end
       end
     rescue ArgumentError => e
-      raise Inferno::Exceptions::TestSuiteImplementationException.new('pas response range criteria', e.message)
+      Inferno::Application['logger'].warn("Ignoring unmatchable requestRange criteria: #{e.message}")
+      false
     end
   end
 end

--- a/spec/davinci_pas_test_kit/client/endpoints/claim_endpoint_spec.rb
+++ b/spec/davinci_pas_test_kit/client/endpoints/claim_endpoint_spec.rb
@@ -181,6 +181,78 @@ RSpec.describe DaVinciPASTestKit::AbstractGatherMustSupportTest, :request do
       expect(returned.entry[0].resource.patient.reference).to eq('Patient/ReferralAuthorizationExample')
     end
 
+    it 'skips an entry with an invalid request range and continues to later entries' do
+      responses = [wrapped_response_bundle(id: 'bad-range', criteria: { 'requestRange' => '3-2' }),
+                   response_bundle(id: 'fallback')]
+      inputs = { session_url_path:, ms_submit_responses: responses.to_json }
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      post_json(submit_url, submit_request_json)
+
+      expect(last_response.status).to be(200)
+      expect(returned_claim_response.id).to eq('fallback')
+    end
+
+    it 'generates a default response when the FHIRPath service returns an error during criteria evaluation' do
+      responses = [wrapped_response_bundle(id: 'needs-fhirpath', criteria: { 'fhirpath' => 'Bundle.id.exists()' })]
+      inputs = { session_url_path:, ms_submit_responses: responses.to_json }
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      stub_request(:post, "#{ENV.fetch('FHIRPATH_URL')}/evaluate")
+        .with(query: { 'path' => 'Bundle.id.exists()' })
+        .to_return(status: 500, body: 'internal error')
+      post_json(submit_url, submit_request_json)
+
+      expect(last_response.status).to be(200)
+      expect(returned_claim_response).to be_a(FHIR::ClaimResponse)
+      expect(returned_claim_response.id).to_not eq('needs-fhirpath')
+    end
+
+    it 'generates a default response when the FHIRPath service cannot be reached' do
+      responses = [wrapped_response_bundle(id: 'needs-fhirpath', criteria: { 'fhirpath' => 'Bundle.id.exists()' })]
+      inputs = { session_url_path:, ms_submit_responses: responses.to_json }
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      stub_request(:post, "#{ENV.fetch('FHIRPATH_URL')}/evaluate")
+        .with(query: { 'path' => 'Bundle.id.exists()' })
+        .to_raise(Faraday::ConnectionFailed.new('connection refused'))
+      post_json(submit_url, submit_request_json)
+
+      expect(last_response.status).to be(200)
+      expect(returned_claim_response).to be_a(FHIR::ClaimResponse)
+    end
+
+    it 'generates a default response when the FHIRPath service fails during token replacement' do
+      bundle = response_bundle(id: 'token-bundle')
+      bundle['entry'][0]['resource']['preAuthRef'] = '{{Bundle.id}}'
+      inputs = { session_url_path:, ms_submit_responses: bundle.to_json }
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      stub_request(:post, "#{ENV.fetch('FHIRPATH_URL')}/evaluate")
+        .with(query: { 'path' => 'Bundle.id' })
+        .to_return(status: 500, body: 'internal error')
+      post_json(submit_url, submit_request_json)
+
+      expect(last_response.status).to be(200)
+      expect(returned_claim_response).to be_a(FHIR::ClaimResponse)
+      expect(returned_claim_response.id).to_not eq('token-bundle')
+    end
+
+    it 'serves tester-provided bundles when the request URL includes a query string' do
+      inputs = { session_url_path:, ms_submit_responses: response_bundle(id: 'query-string-bundle').to_json }
+      result = run(test, inputs)
+      expect(result.result).to eq('wait')
+
+      post_json("#{submit_url}?foo=bar", submit_request_json)
+
+      expect(last_response.status).to be(200)
+      expect(returned_claim_response.id).to eq('query-string-bundle')
+    end
+
     it 'generates a default response when no provided entry matches' do
       responses = [wrapped_response_bundle(id: 'never-selected', criteria: { 'requestRange' => '5' })]
       inputs = { session_url_path:, ms_submit_responses: responses.to_json }

--- a/spec/davinci_pas_test_kit/client/user_input_response_spec.rb
+++ b/spec/davinci_pas_test_kit/client/user_input_response_spec.rb
@@ -40,22 +40,28 @@ RSpec.describe DaVinciPASTestKit::UserInputResponse do
       expect(described_class.response_candidates(result, 'submit')).to be_nil
     end
 
-    it 'returns nil when the input is not valid JSON' do
+    it 'returns nil and logs when the input is not valid JSON' do
       result = result_with_input('ms_submit_responses', 'not json')
+      allow(Inferno::Application['logger']).to receive(:warn)
 
       expect(described_class.response_candidates(result, 'submit')).to be_nil
+      expect(Inferno::Application['logger']).to have_received(:warn).with(/not valid JSON/)
     end
 
-    it 'returns nil when the input contains entries that are not objects' do
+    it 'returns nil and logs the entry number when an entry is not an object' do
       result = result_with_input('ms_submit_responses', [bundle_a, 'not a bundle'].to_json)
+      allow(Inferno::Application['logger']).to receive(:warn)
 
       expect(described_class.response_candidates(result, 'submit')).to be_nil
+      expect(Inferno::Application['logger']).to have_received(:warn).with(/entry 2/)
     end
 
-    it 'returns nil when a wrapper is missing its bundle' do
+    it 'returns nil and logs when a wrapper is missing its bundle' do
       result = result_with_input('ms_submit_responses', [{ 'criteria' => { 'requestRange' => '1' } }].to_json)
+      allow(Inferno::Application['logger']).to receive(:warn)
 
       expect(described_class.response_candidates(result, 'submit')).to be_nil
+      expect(Inferno::Application['logger']).to have_received(:warn).with(/entry 1/)
     end
   end
 end

--- a/spec/davinci_pas_test_kit/cross_suite/response_selection_utils_spec.rb
+++ b/spec/davinci_pas_test_kit/cross_suite/response_selection_utils_spec.rb
@@ -39,47 +39,35 @@ RSpec.describe DaVinciPASTestKit::ResponseSelectionUtils do
 
   describe '#include_entity?' do
     it 'includes a bare bundle' do
-      expect(utils.include_entity?(inner_bundle, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(inner_bundle, request_bundle, 1)).to be(true)
     end
 
     it 'includes a wrapper with no criteria' do
-      expect(utils.include_entity?(wrapper, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(wrapper, request_bundle, 1)).to be(true)
     end
 
     it 'includes a wrapper whose request range covers the current request number' do
-      stub_previous_requests
-
       entity = wrapper({ 'requestRange' => '1' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(true)
     end
 
     it 'excludes a wrapper whose request range does not cover the current request number' do
-      stub_previous_requests
-
       entity = wrapper({ 'requestRange' => '2-3' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(false)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(false)
     end
 
     it 'accepts a request range given as a number' do
-      stub_previous_requests
-
       entity = wrapper({ 'requestRange' => 1 })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(true)
     end
 
-    it 'counts only previous successful requests to the same operation' do
-      stub_previous_requests(
-        previous_request('https://inferno.test/custom/suite/fhir/Claim/$submit'),
-        previous_request('https://inferno.test/custom/suite/fhir/Claim/$submit', 400),
-        previous_request('https://inferno.test/custom/suite/fhir/Claim/$inquire')
-      )
+    it 'excludes a wrapper with an invalid request range instead of raising' do
+      entity = wrapper({ 'requestRange' => '1-2,a' })
 
-      entity = wrapper({ 'requestRange' => '2' })
-
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(false)
     end
 
     it 'includes a wrapper whose fhirpath criteria evaluate to true against the request' do
@@ -87,7 +75,7 @@ RSpec.describe DaVinciPASTestKit::ResponseSelectionUtils do
 
       entity = wrapper({ 'fhirpath' => 'Bundle.id.exists()' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(true)
     end
 
     it 'excludes a wrapper whose fhirpath criteria evaluate to false against the request' do
@@ -95,7 +83,7 @@ RSpec.describe DaVinciPASTestKit::ResponseSelectionUtils do
 
       entity = wrapper({ 'fhirpath' => 'Bundle.id.exists()' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(false)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(false)
     end
 
     it 'excludes a wrapper whose fhirpath criteria return no results' do
@@ -103,25 +91,23 @@ RSpec.describe DaVinciPASTestKit::ResponseSelectionUtils do
 
       entity = wrapper({ 'fhirpath' => 'Bundle.wrong' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(false)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(false)
     end
 
     it 'requires both criteria to be met when both are present' do
-      stub_previous_requests
       stub_fhirpath_service('Bundle.id.exists()', [{ type: 'boolean', element: false }])
 
       entity = wrapper({ 'requestRange' => '1', 'fhirpath' => 'Bundle.id.exists()' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(false)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(false)
     end
 
     it 'includes a wrapper when both criteria are met' do
-      stub_previous_requests
       stub_fhirpath_service('Bundle.id.exists()', [{ type: 'boolean', element: true }])
 
       entity = wrapper({ 'requestRange' => '1', 'fhirpath' => 'Bundle.id.exists()' })
 
-      expect(utils.include_entity?(entity, request_bundle, '$submit')).to be(true)
+      expect(utils.include_entity?(entity, request_bundle, 1)).to be(true)
     end
   end
 
@@ -149,6 +135,18 @@ RSpec.describe DaVinciPASTestKit::ResponseSelectionUtils do
     end
   end
 
+  describe '#count_previous_successful_requests' do
+    it 'counts only successful requests to the given operation' do
+      stub_previous_requests(
+        previous_request('https://inferno.test/custom/suite/fhir/Claim/$submit'),
+        previous_request('https://inferno.test/custom/suite/fhir/Claim/$submit', 400),
+        previous_request('https://inferno.test/custom/suite/fhir/Claim/$inquire')
+      )
+
+      expect(utils.count_previous_successful_requests('$submit')).to eq(1)
+    end
+  end
+
   describe '#ranges_cover_value?' do
     it 'supports comma-separated single values and ranges' do
       expect(utils.ranges_cover_value?(1, '1-2,4')).to be(true)
@@ -156,14 +154,18 @@ RSpec.describe DaVinciPASTestKit::ResponseSelectionUtils do
       expect(utils.ranges_cover_value?(4, '1-2,4')).to be(true)
     end
 
-    it 'raises a TestSuiteImplementationException for an invalid range string' do
-      expect { utils.ranges_cover_value?(1, 'one') }
-        .to raise_error(Inferno::Exceptions::TestSuiteImplementationException, /Invalid range string/)
+    it 'logs and returns false for an invalid range string' do
+      allow(Inferno::Application['logger']).to receive(:warn)
+
+      expect(utils.ranges_cover_value?(1, 'one')).to be(false)
+      expect(Inferno::Application['logger']).to have_received(:warn).with(/Invalid range string/)
     end
 
-    it 'raises a TestSuiteImplementationException for an inverted range' do
-      expect { utils.ranges_cover_value?(1, '3-2') }
-        .to raise_error(Inferno::Exceptions::TestSuiteImplementationException, /Inverted range/)
+    it 'logs and returns false for an inverted range' do
+      allow(Inferno::Application['logger']).to receive(:warn)
+
+      expect(utils.ranges_cover_value?(1, '3-2')).to be(false)
+      expect(Inferno::Application['logger']).to have_received(:warn).with(/Inverted range/)
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-up cleanup for the criteria-based response selection introduced in #79, addressing code review feedback. The selection semantics are unchanged; these changes harden error handling so that tester input or environment problems produce a logged default response instead of an HTTP 500 to the client under test, and clean up a few internals:

- An invalid or inverted `requestRange` (for example `"1-2,a"` or `"3-2"`) no longer raises. It is logged and treated as unmet, so the entry is skipped and later entries are still considered.
- FHIRPath service failures (non-2xx responses, unreachable service, unparseable response bodies) during criteria evaluation or token replacement are rescued in the endpoint. Inferno logs a warning and generates a default response.
- The operation is now parsed with the query string stripped, so requests to `.../Claim/$submit?param=value` are tagged, counted, and matched correctly.
- When a response input is present but unusable (invalid JSON, or an entry that is neither a Bundle nor a wrapper with a `bundle` key), the reason and offending entry number are logged instead of silently falling back to default responses.
- The request number is computed once per request instead of once per candidate with a `requestRange` criterion, removing redundant repository queries.
- Removed a dead `rescue` in token replacement and skipped the FHIR round trip when the selected bundle contains no tokens.
- The `ms_submit_responses` / `ms_inquire_responses` input descriptions are now generated from a single shared helper in `client_input_descriptions.rb` so the documentation cannot drift between the two inputs.
- FHIRPath service error messages no longer interpolate the full serialized resource.

## How to test

Run the suites against each other following `docs/Running-Suites-Against-Each-Other.md`:
client suite session (Da Vinci PAS Client Suite v2.2.1, Other Authentication, preset
"Run Against the PAS Server Suite") in one tab, server suite session (preset
"Run Against the PAS Client Suite") in another.

### Regression: existing behavior unchanged

1. In the client session, run group `10 Must Support Elements`
   (`pas_client_v221_must_support_no_auth`) and leave test `10.1.01`
   (`pas_client_v221_gather_must_support`) waiting.
2. In the server session, run groups `3.1 $submit Element Support` and
   `3.2 $inquire Element Support`.
3. Back in the client session, click the confirmation link in the `10.1.01` wait dialog
   and complete the attestations.

Expected: the group passes as before, including `10.2.01`
(`pas_client_v221_request_bundle_validation_test`) and `10.2.02`
(`pas_client_v221_response_bundle_validation_test`).

### Error handling scenarios

Run group `10 Must Support Elements` with the `Must Support $submit Response Bundles`
input set to a list whose first entry is a wrapper with an invalid range and whose
second entry is a plain Bundle:

    [
      { "criteria": { "requestRange": "3-2" }, "bundle": { ...bundle A... } },
      { ...bundle B... }
    ]

Send a `$submit` request to the endpoint shown in the `10.1.01` wait dialog. Expected:
HTTP 200 with bundle B returned (the invalid entry is skipped), and the server log
contains "Ignoring unmatchable requestRange criteria".

With the FHIRPath service stopped (`docker stop <fhirpath container>`), provide an
entry with a `fhirpath` criterion and send a request. Expected: HTTP 200 with a
generated default response and a logged warning, rather than an HTTP 500.

Send a `$submit` request with a query string appended to the endpoint URL
(for example `...$submit?param=value`). Expected: the tester-provided bundle is still
returned and the request is counted normally.

Provide input that is not valid JSON, or a wrapper entry missing its `bundle` key.
Expected: default responses, with a log line naming the input and the offending entry.

### Where to verify results

- Test `10.2.01`: the REQUESTS tab lists the received `$submit` requests; open DETAILS
  on a request and expand Response Body to see which bundle was returned.
- The Inferno server log shows one line per request: the selection decisions
  ("Selected tester-provided response bundle N of M...") and the new warnings for
  invalid ranges, unusable inputs, and FHIRPath service failures.
- The run dialog for group `10 Must Support Elements` shows the (now shared) input
  documentation on both response inputs.