### PR TITLE
ID-167: suite endpoints custom no session response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'inferno_core', path: '../inferno-core'
+
 gem "rubocop"
 gem 'rubocop-rspec', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,41 @@
 PATH
+  remote: ../inferno-core
+  specs:
+    inferno_core (1.4.1)
+      activesupport (~> 7.2.3.1)
+      base62-rb (= 0.3.1)
+      blueprinter (= 0.25.2)
+      concurrent-ruby (~> 1.3, >= 1.3.7)
+      csv (~> 3.3.5)
+      dotenv (~> 2.7)
+      dry-configurable (= 1.0.0)
+      dry-container (= 0.10.0)
+      dry-core (= 1.0.0)
+      dry-inflector (= 1.0.0)
+      dry-system (= 1.0.0)
+      faraday (~> 1.10.6)
+      faraday_middleware (~> 1.2)
+      fhir_client (>= 6.2.0)
+      fhir_models (>= 5.1.0)
+      hanami-controller (= 2.0.0)
+      hanami-router (= 2.0.0)
+      kramdown (~> 2.5.2)
+      kramdown-parser-gfm (~> 1.1.0)
+      mutex_m (~> 0.3.0)
+      oj (~> 3.17, >= 3.17.3)
+      pastel (~> 0.8.0)
+      pry
+      pry-byebug
+      puma (~> 8.0, >= 8.0.2)
+      rake (~> 13.0)
+      roo (~> 2.10.1)
+      sequel (~> 5.42.0)
+      sidekiq (~> 7.3.10)
+      sqlite3 (~> 1.4)
+      thor (~> 1.4)
+      tty-markdown (~> 0.7.1)
+
+PATH
   remote: .
   specs:
     davinci_pas_test_kit (0.15.1)
@@ -41,7 +78,7 @@ GEM
     byebug (13.0.0)
       reline (>= 0.6.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
@@ -160,39 +197,6 @@ GEM
       mutex_m
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    inferno_core (1.4.0)
-      activesupport (~> 7.2.3.1)
-      base62-rb (= 0.3.1)
-      blueprinter (= 0.25.2)
-      concurrent-ruby (= 1.3.4)
-      csv (~> 3.3.5)
-      dotenv (~> 2.7)
-      dry-configurable (= 1.0.0)
-      dry-container (= 0.10.0)
-      dry-core (= 1.0.0)
-      dry-inflector (= 1.0.0)
-      dry-system (= 1.0.0)
-      faraday (~> 1.10.5)
-      faraday_middleware (~> 1.2)
-      fhir_client (>= 6.2.0)
-      fhir_models (>= 5.1.0)
-      hanami-controller (= 2.0.0)
-      hanami-router (= 2.0.0)
-      kramdown (~> 2.5.2)
-      kramdown-parser-gfm (~> 1.1.0)
-      mutex_m (~> 0.3.0)
-      oj (~> 3.17, >= 3.17.3)
-      pastel (~> 0.8.0)
-      pry
-      pry-byebug
-      puma (~> 8.0, >= 8.0.2)
-      rake (~> 13.0)
-      roo (~> 2.10.1)
-      sequel (~> 5.42.0)
-      sidekiq (~> 7.3.10)
-      sqlite3 (~> 1.4)
-      thor (~> 1.4)
-      tty-markdown (~> 0.7.1)
     io-console (0.8.2)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -423,6 +427,7 @@ DEPENDENCIES
   debug
   factory_bot (~> 6.1)
   foreman
+  inferno_core!
   rack-test
   rspec (~> 3.10)
   rubocop

--- a/lib/davinci_pas_test_kit/client/endpoints/claim_endpoint.rb
+++ b/lib/davinci_pas_test_kit/client/endpoints/claim_endpoint.rb
@@ -20,6 +20,12 @@ module DaVinciPASTestKit
       request.path.split('/custom/')[1].split('/')[0] # request.path = {base inferno path}/custom/{suite_id}/...
     end
 
+    error_response_format :operation_outcome
+
+    def test_run_identifier_location_description
+      'the path or embedded within the bearer token in the Authorization header'
+    end
+
     def test_run_identifier
       return request.params[:session_path] if request.params[:session_path].present?
 

--- a/lib/davinci_pas_test_kit/client/endpoints/subscription_create_endpoint.rb
+++ b/lib/davinci_pas_test_kit/client/endpoints/subscription_create_endpoint.rb
@@ -6,6 +6,12 @@ module DaVinciPASTestKit
   class SubscriptionCreateEndpoint < Inferno::DSL::SuiteEndpoint
     include SubscriptionsTestKit::SubscriptionsR5BackportR4Client::SubscriptionSimulationUtils
 
+    error_response_format :operation_outcome
+
+    def test_run_identifier_location_description
+      'the path or embedded within the bearer token in the Authorization header'
+    end
+
     def test_run_identifier
       return request.params[:session_path] if request.params[:session_path].present?
 

--- a/lib/davinci_pas_test_kit/client/endpoints/subscription_status_endpoint.rb
+++ b/lib/davinci_pas_test_kit/client/endpoints/subscription_status_endpoint.rb
@@ -6,6 +6,12 @@ module DaVinciPASTestKit
     include SubscriptionsTestKit::SubscriptionsR5BackportR4Client::SubscriptionSimulationUtils
     include ResponseGenerator
 
+    error_response_format :operation_outcome
+
+    def test_run_identifier_location_description
+      'the path or embedded within the bearer token in the Authorization header'
+    end
+
     def test_run_identifier
       return request.params[:session_path] if request.params[:session_path].present?
 

--- a/lib/davinci_pas_test_kit/client/endpoints/token_endpoint.rb
+++ b/lib/davinci_pas_test_kit/client/endpoints/token_endpoint.rb
@@ -14,6 +14,20 @@ module DaVinciPASTestKit
         UDAPSecurityTestKit::MockUDAPServer.client_id_from_client_assertion(request.params[:client_assertion])
       end
 
+      def test_run_identifier_location_description
+        "the client assertion's 'iss' claim representing the client's id"
+      end
+
+      def no_session_response
+        response.status = 401
+        response.format = :json
+        response.body = {
+          error: 'invalid_client',
+          error_description: no_session_message
+
+        }.to_json
+      end
+
       def make_response
         if request.params[:udap].present?
           make_udap_client_credential_token_response

--- a/spec/davinci_pas_test_kit/client/endpoints/no_session_response_spec.rb
+++ b/spec/davinci_pas_test_kit/client/endpoints/no_session_response_spec.rb
@@ -1,0 +1,51 @@
+require 'udap_security_test_kit'
+require_relative '../../../../lib/davinci_pas_test_kit/client/client_urls'
+
+# Verifies the response returned by each client suite endpoint when no waiting test
+# run/session can be found for an incoming request.
+RSpec.shared_examples 'a no-session OperationOutcome response' do
+  it 'returns a 500 OperationOutcome' do
+    post_json(request_path, {})
+
+    expect(last_response.status).to eq(500)
+    expect(last_response.headers['Content-Type']).to eq('application/fhir+json')
+
+    outcome = FHIR.from_contents(last_response.body)
+    expect(outcome).to be_a(FHIR::OperationOutcome)
+    expect(outcome.issue.first.code).to eq('not-found')
+    expect(outcome.issue.first.details.text).to include('Unable to find test run')
+  end
+end
+
+RSpec.describe DaVinciPASTestKit::ClaimEndpoint, :request do
+  it_behaves_like 'a no-session OperationOutcome response' do
+    let(:request_path) { "/custom/davinci_pas_client_suite_v201#{DaVinciPASTestKit::SUBMIT_PATH}" }
+  end
+
+  describe DaVinciPASTestKit::SubscriptionCreateEndpoint do
+    it_behaves_like 'a no-session OperationOutcome response' do
+      let(:request_path) { "/custom/davinci_pas_client_suite_v201#{DaVinciPASTestKit::FHIR_SUBSCRIPTION_PATH}" }
+    end
+  end
+
+  describe DaVinciPASTestKit::SubscriptionStatusEndpoint do
+    it_behaves_like 'a no-session OperationOutcome response' do
+      let(:request_path) do
+        "/custom/davinci_pas_client_suite_v201#{DaVinciPASTestKit::FHIR_SUBSCRIPTION_RESOURCE_STATUS_PATH}"
+      end
+    end
+  end
+
+  describe DaVinciPASTestKit::MockUdapSmartServer::TokenEndpoint do
+    it 'returns a 401 response with an OAuth-style JSON error body' do
+      post "/custom/davinci_pas_client_suite_v201#{UDAPSecurityTestKit::TOKEN_PATH}"
+
+      expect(last_response.status).to eq(401)
+      expect(last_response.headers['Content-Type']).to include('application/json')
+
+      body = JSON.parse(last_response.body)
+      expect(body['error']).to eq('invalid_client')
+      expect(body['error_description']).to include('Unable to find test run')
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Use the new core Suite Endpoint functionality to return FHIR OperationOutcomes on errors instead of plain text response, as well as OAuth unauthorized responses for the token endpoint.

# Testing Guidance

TODO
