### PR TITLE
FQM-440: Add v2.2.1 Server Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Da Vinci Prior Authorization Support (PAS) Test Kit
 
 The **Da Vinci Prior Authorization Support (PAS) Test Kit** validates the 
-conformance of systems to versions 2.0.1 and 2.1.1 of the PAS FHIR IG. The test kit includes
+conformance of systems to versions 2.0.1 and 2.2.1 of the PAS FHIR IG. The test kit includes
 suites targeting each of the actors from the specification:
 
 - Servers (payers): Inferno will act as a client and make a series of
@@ -66,6 +66,7 @@ Detailed step-by-step instructions for running the tests can be found in our wal
 - [Client v2.0.1 Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Instructions-v2.0.1)
 - [Client v2.2.1 Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Client-Instructions-v2.2.1)
 - [Server v2.0.1 Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Instructions-v2.0.1)
+- [Server v2.2.1 Testing Walkthrough](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Instructions-v2.2.1)
 
 Additional information is provided in the [Da Vinci PAS Test Kit documentation](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/).
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -44,7 +44,7 @@ This test kit is a **DRAFT**. While it covers core aspects of the PAS IG, there 
 
 The test kit currently focuses on validating core end-to-end prior authorization
 workflows, including the submission and handling of responses for prior
-authorization requests (approval, denial, pended). It also covers FHIR profile
+authorization requests (approval, denial, pended) and claim updates. It also covers FHIR profile
 conformance, validation of must-support elements as defined in PAS IG profiles,
 basic subscription mechanics for pended request notifications, and core
 authentication flows like SMART Backend Services and UDAP B2B.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -80,3 +80,4 @@ For specific testing prerequisites and detailed test descriptions, refer to:
 * [Client v2.0.1 Instructions](Client-Instructions-v2.0.1.md)
 * [Client v2.2.1 Instructions](Client-Instructions-v2.2.1.md)
 * [Server v2.0.1 Instructions](Server-Instructions-v2.0.1.md)
+* [Server v2.2.1 Instructions](Server-Instructions-v2.2.1.md)

--- a/docs/Running-Suites-Against-Each-Other.md
+++ b/docs/Running-Suites-Against-Each-Other.md
@@ -143,7 +143,7 @@ in progress, so some tests do not fully align yet.
     *   Click the "Run Tests" button (typically found in the top-right).
     *   A dialog will appear showing the pre-filled inputs from the preset. You can review them if you wish. Click the "SUBMIT" button (usually at the bottom-right of the dialog) to start execution of the test run.
     *   Inferno will submit a series of PAS request to the client suite session. Wait for the server tests to complete.
-    *   Once the server suite tests have completed, return to the client suite sessio and confirm that they have completed as well.
+    *   Once the server suite tests have completed, return to the client suite session and confirm that they have completed as well.
 9.  **Must Support Elements Execution**:
     *   In the client session, select the "**12** Must Support Elements" group from the sidebar (typically found on the left side).
     *   Click the "Run Tests" button (typically found in the top-right).
@@ -151,11 +151,11 @@ in progress, so some tests do not fully align yet.
     *   A "User Action Required" dialog will appear indicating that Inferno is waiting for a $submit request.
     *   Return to the server suite test session.
     *   In the server suite session, select the "**3** Demonstrate Element Support" group from the sidebar (typically found on the left side).
-    *   Click the "Run Tests" button (typically found in the top-right).
+    *   Click the "Run All Tests" button (typically found in the top-right).
     *   A dialog will appear showing the pre-filled inputs from the preset. You can review them if you wish. Click the "SUBMIT" button (usually at the bottom-right of the dialog) to start execution of the test run.
     *   Inferno will submit a series of PAS request to the client suite session and then verify that the requests and responses demonstrate all must support elements. Wait for the server tests to complete.
     *   Once the server suite tests have completed, return to the client suite session. Click the link to indicate that all requests have been sent. A new "User Action Required" dialog will appear asking for an attestation that the client system handled the $submit response must support elements appropriately. Click the statement indicating that it was and then do the same in the next dialog asking about the $inquire response must support elements to complete the tests.
-10.  **Operation Failure Execution**:
+10. **Operation Failure Execution**:
     *   In the client session, select the "**13.1** Operation Failure" group from the sidebar (typically found on the left side).
     *   Click the "Run Tests" button (typically found in the top-right).
     *   A dialog will appear showing the pre-filled inputs from the preset. You can review them if you wish. Click the "SUBMIT" button (usually at the bottom-right of the dialog) to start execution.

--- a/docs/Server-Details.md
+++ b/docs/Server-Details.md
@@ -1,10 +1,9 @@
 # Server Suite Implementation Details
 
 The Da Vinci PAS Server Suite validates the conformance of server systems 
-to the STU 2 version of the HL7® FHIR® 
-[Da Vinci Prior Authorization Support Implementation Guide](https://hl7.org/fhir/us/davinci-pas/STU2/).
-There is also an in-progress suite for the [2.2.1 version of the IG](https://hl7.org/fhir/us/davinci-pas/2.2.1/).
-The documentation on this wiki currently covers only the 2.0.1 version of the server suite.
+to versions [2.0.1](https://hl7.org/fhir/us/davinci-pas/STU2/) and
+[2.2.1](https://hl7.org/fhir/us/davinci-pas/2.2.1/) of the HL7® FHIR® Da Vinci Prior Authorization Support Implementation Guide.
+This documentation covers both versions of the server suite.
 
 These tests are a **DRAFT** intended to allow PAS server implementers to perform 
 preliminary checks of their servers against PAS IG requirements and [provide 
@@ -21,6 +20,7 @@ conformant handling of PAS requirements, including
     - Approval of a prior authorization request
     - Denial of a prior authorization request
     - Pending of a prior authorization request and a subsequent final decision
+    - Claim Updates (v2.2.1 only)
     - Inability to process a prior authorization request
 - The ability of the server to handle the full scope of data required by PAS, including
     - Ability to process prior auth requests and inquiries with all PAS profiles and all must support elements on those profiles
@@ -35,6 +35,8 @@ IG requirements individually and used in aggregate to determine whether
 required features and functionality are present. HL7® FHIR® resources are 
 validated with the Java validator using `tx.fhir.org` as the terminology server.
 
+The v2.2.1 suite validates resources against the PAS 2.2.1 and US Core 6.1.0 implementation guides.
+
 These tests do not currently test the full scope of the IG. See the *Testing Limitations* section below 
 for more details about the current scope of the tests and the reasons that some details have been left out.
 
@@ -44,6 +46,9 @@ for more details about the current scope of the tests and the reasons that some 
 
 Execution of these tests require a significant amount of tester input in the
 form of requests that Inferno will make against the server under test.
+
+For v2.2.1, see the [v2.2.1 server instructions](Server-Instructions-v2.2.1) for version-specific
+setup and execution steps. The public reference server example below applies to v2.0.1.
 
 If you would like to try out the tests using examples from the IG against the
 [public reference server endpoint](https://prior-auth.davinci.hl7.org/fhir) ([code on github](https://github.com/HL7-DaVinci/prior-auth)), you can do so by 
@@ -65,7 +70,7 @@ that appears when initiating a test run.
 
 ### Server identification
 
-Requests will be made to the `/Claim/$submit` and `/Claim/$inquire` endpoints under the url provided in the "FHIR Server Endpoint URL" field.
+Requests will be made to the `/Claim/$submit`, `/Claim/$inquire`, and `/Subscription` endpoints under the url provided in the "FHIR Server Endpoint URL" field.
 
 ### Authentication
 
@@ -73,11 +78,11 @@ The PAS IG states that
 
 > "PAS Servers **SHOULD** support server-server OAuth… In a future release of this guide, direction will limit the option to [require] server-server OAuth."
 
-The PAS test kit currently assumes that the handshake has already occurred and requires
-that a bearer token be provided in the “OAuth Credentials / Access Token” configuration
-field. Inferno will submit this token on all requests it makes to the server as a part of 
-executing the tests. A complete backend server authentication handshake may be supported
-in future versions of the test kit.
+The **OAuth Credentials** input is optional for test environments that do not require authentication.
+When authentication is required, it must authorize Inferno to invoke the PAS operations and create the
+Subscription. The v2.2.1 suite accepts an access-token or backend-service configuration and uses it to
+obtain or apply credentials to its outbound requests. The server suite does not separately evaluate an
+OAuth interaction as a server-test result.
 
 ### Payload
 
@@ -88,6 +93,21 @@ and instead relies on the tester to provide the requests that Inferno will make.
 For single-request fields (e.g., “PAS Submit Request Payload for Approval Response”), the input must be a json-encoded FHIR bundle.
 
 For multiple-request fields (e.g., “Additional PAS Submit Request Payloads”), the input must be a json array of json-encoded FHIR bundles (e.g., [fhir-bundle-1, fhir-bundle-2, …] where each fhir-bundle-n is a full bundle).
+
+### Claim Updates (v2.2.1)
+
+The v2.2.1 **Claim Updates** group sends four tester-provided `$submit` requests in order: an initial Claim
+submission, an update that adds an item, an update that modifies one item and cancels another, and an update that
+cancels the entire request. The Bundles must form a stateful sequence for the server under test.
+
+Inferno validates each response against the corresponding request: each response must echo submitted item sequences
+and include current results for all submitted items. It does not compare item sequences between different update steps.
+
+### Error handling (v2.2.1)
+
+The **Demonstrate Error Handling** group requires no tester-provided error payload. Inferno submits an intentionally
+nonconformant, empty Bundle to both `$submit` and `$inquire`. The server is expected to return a non-2xx response
+containing an `OperationOutcome`.
 
 ### Subscription
 
@@ -109,6 +129,9 @@ the `Claim/$submit` operation and that it uses the same authentication. Testers 
 
 During the pended workflow test, testers will demonstrate that an update to the submitted and pended prior authorization
 request causes the Subscription to trigger and send a notification to Inferno.
+
+The v2.0.1 and v2.2.1 pended workflows differ in that Inferno expects `id-only` notification content in v2.0.1 and
+`full-resource` notification content in v2.2.1.
 
 ## Testing Limitations
 
@@ -138,9 +161,7 @@ The implications of this reliance on proprietary information that is not publicl
 kit:
 
 - Cannot verify the correct usage of X12-based terminology: terminology requirements for all elements bound to X12
-    value sets will not be validated.
-- Cannot verify the meaning of codes: validation that a given response conveys something specific, e.g., approval
-    or pending, is not performed.
+    value sets will not be validated beyond the expected codes indicating approval, denial, and pended decisions.
 - Cannot verify matching semantics on inquiries: no checking of the identity of the ClaimResponse returned for an
     inquiry, e.g., that it matches the input or the original request.
 
@@ -152,7 +173,7 @@ if these requirements are not met.
 
 The PAS IG places additional requirements on servers that are not currently tested by this test kit, including
 
-- Prior Authorization update workflows
+- Prior Authorization update workflows (v2.0.1)
 - Requests for additional information handled through the CDex framework
 - PDF, CDA, and JPG attachments
 - US Core profile support for supporting information

--- a/docs/Server-Details.md
+++ b/docs/Server-Details.md
@@ -81,7 +81,7 @@ The PAS IG states that
 The **OAuth Credentials** input is optional for test environments that do not require authentication.
 When authentication is required, it must authorize Inferno to invoke the PAS operations and create the
 Subscription. The v2.2.1 suite accepts an access-token or backend-service configuration and uses it to
-obtain or apply credentials to its outbound requests. The server suite does not separately evaluate an
+apply credentials to its outbound requests. The server suite does not separately evaluate an
 OAuth interaction as a server-test result.
 
 ### Payload

--- a/docs/Server-Instructions-v2.2.1.md
+++ b/docs/Server-Instructions-v2.2.1.md
@@ -1,0 +1,136 @@
+# Da Vinci PAS Test Kit: Server Testing v2.2.1 Instructions
+
+This document provides a step-by-step guide for running the Da Vinci PAS Test Kit to test a **server system (payer)**
+against v2.2.1 of the IG. In this scenario, Inferno acts as the PAS client.
+
+## Pre-execution Setup and Required Information
+
+### Minimum Requirements
+
+To run against the Da Vinci PAS Server v2.2.1 Test Suite, a PAS server implementation must at minimum
+be able to receive PAS `$submit` requests from Inferno. Inferno must be able to reach the server's
+FHIR base URL, and the server must accept requests at the `/Claim/$submit` endpoint under that base URL.
+
+To perform a simple approval workflow, testers will need:
+
+- The FHIR base URL for the PAS server under test.
+- OAuth credentials, if the server requires authentication. The suite assumes any required authentication
+  setup has been completed before the test run and uses the credentials supplied in the **OAuth Credentials**
+  input when making requests to the server.
+- A complete JSON-encoded PAS Request Bundle that will result in a prior authorization approval when
+  sent to the server.
+
+### Passing Requirements
+
+Additional configuration and information is needed to demonstrate conformance to all tests in the suite.
+In order to pass all tests in the suite, a PAS server implementation must
+
+- Support the `$submit` and `$inquire` operations at the expected endpoints.
+- Return the expected approval, denial, and pended outcomes for the tester-provided requests.
+- Support creation of a REST-hook Subscription, including a handshake notification and a full-resource
+  notification when a pended Claim is finalized.
+- Receive the sequence of Claim Update `$submit` requests used by the Claim Updates group (add an 
+  item, modify an item, cancel an item, cancel the request).
+
+Because the business logic that determines decisions and the elements populated in responses varies between
+implementers, testers must provide the request Bundles that Inferno will send to the server. To pass the
+Must Support Elements group, those Bundles must collectively contain and elicit the required content. See the
+[Server Testing Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)
+documentation for technical implementation details and known limitations.
+
+### Network Preparation
+
+The pended workflow requires connectivity in both directions: Inferno must reach the server, and the server
+must be able to send REST-hook notifications to the endpoint placed in the Subscription by Inferno. Ensure that
+outbound network rules, proxy settings, and TLS configuration allow the server to reach that endpoint before
+starting the Subscription Setup group.
+
+## Quick Start
+
+To execute a simple set of tests with minimal setup and input, perform an approval workflow with the
+following steps:
+
+1. Create a Da Vinci PAS Server Suite v2.2.1 session.
+1. Select the "Successful Approval Workflow" group from the list at the left and click the "RUN TESTS"
+   button in the upper right.
+1. In the input dialog, provide the following values:
+   - **FHIR Server Endpoint URL**: the base FHIR URL for the PAS server. Inferno appends
+     `/Claim/$submit` when it sends the approval request.
+   - **OAuth Credentials**: the credentials Inferno should use if authentication is required by the server.
+   - **PAS Submit Request Payload for Approval Response**: a complete JSON-encoded PAS Request Bundle
+     that will result in a claim approval from the server.
+1. Click the "SUBMIT" button at the bottom right of the dialog.
+1. Inferno validates the supplied request Bundle, sends it to `/Claim/$submit`, and validates the response.
+1. Review the results including any errors or warnings found when checking the supplied request and the
+   server response.
+
+## Additional Testing Options
+
+The following groups and inputs can be used to expand the process described in the
+[Quick Start](#quick-start) section into a complete set of tests.
+
+### Testing the Denial Workflow
+
+Run the "Successful Denial Workflow" group in the same manner as the approval workflow. Provide a
+**PAS Submit Request Payload for Denial Response** that is expected to result in a denial from the
+server under test.
+
+### Testing the Pended Workflow
+
+To run the "Successful Pended Workflow" group, first run the "Subscription Setup" group. Provide a
+**Pended Prior Authorization Subscription** resource in JSON format and a **Notification Access Token**.
+Inferno validates the supplied Subscription and modifies its channel endpoint so that the server sends
+notifications to Inferno. Inferno also ensures that the Subscription contains the supplied token as a
+`Bearer` token in the `Authorization` header sent by the server to Inferno.
+
+The Subscription Setup group sends the Subscription to the server and waits for a handshake notification.
+After it completes, run the "Successful Pended Workflow" group with a **PAS Submit Request Payload for
+Pended Response** that will result in a pended response from the server. After the server returns the
+pended response, finalize the pended claim in the server's workflow so that it sends a full-resource event
+notification to Inferno. Inferno automatically resumes when it receives the event notification, and then
+it validates the notification content.
+
+### Testing Claim Updates
+
+The **Claim Updates** group sends four `$submit` requests in order:
+
+1. An initial Claim submission.
+1. An update that adds an item.
+1. An update that modifies one item and cancels another.
+1. An update that cancels the entire request.
+
+Provide the four corresponding JSON-encoded Bundles in the inputs for this group. Construct them as a
+single, stateful sequence in the server's test environment: each update must refer to the appropriate
+previous Claim and the server must return a response for every step. Inferno validates each supplied
+Bundle and response, then checks the item sequences returned across the sequence.
+
+### Testing Must Support Elements
+
+During the **Demonstrate Element Support** group, Inferno sends one or more additional `$submit` and
+`$inquire` requests and then checks the requests and responses for the required must support elements.
+Provide JSON-encoded Bundles in the **Additional $submit Request Payloads** and **Additional $inquire
+Request Payloads** inputs. Each input may contain one Bundle or a JSON array of Bundles, for example
+`[bundle_1, bundle_2]` where each value is a complete Bundle. The Must Support Elements tests use the
+`$submit` and `$inquire` requests already sent during the test session in addition to the requests
+supplied for this group.
+
+### Testing Error Handling
+
+The **Demonstrate Error Handling** group does not require a tester-provided error payload. Inferno sends
+an intentionally empty Bundle to both `/Claim/$submit` and `/Claim/$inquire`. The server
+is expected to return a non-2xx response containing an `OperationOutcome`.
+
+## Interpreting Results
+
+Due to [limitations of these tests](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Overview#test-scope-and-limitations),
+passing this test suite in its entirety [does not prove conformance to the specification](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Overview#conformance-criteria--interpreting-results).
+
+The request Bundle validation tests are marked as **Simulation Verifcation**. A skip in one of these tests
+means Inferno deemed the supplied Bundle invalid. These validation errors should be considered when
+interpreting the results of the subsequent tests that validate the server response.
+
+## Inferno Client vs Server Execution
+
+For a demonstration of the v2.2.1 server suite against Inferno's simulated PAS client rather than a
+separate PAS implementation, see the instructions for
+[running the Inferno client and server suites against each other](Running-Suites-Against-Each-Other).

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -12,6 +12,7 @@
 **Server Suite**
 *   [Server Testing Details](Server-Details)
 *   [Server v2.0.1 Testing Instructions](Server-Instructions-v2.0.1)
+*   [Server v2.2.1 Testing Instructions](Server-Instructions-v2.2.1)
 
 **Contributing to this Test Kit**
 *   [Technical Overview](Technical-Overview)

--- a/lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb
+++ b/lib/davinci_pas_test_kit/generator/templates/server_suite.rb.erb
@@ -22,8 +22,7 @@ module DaVinciPASTestKit
 
         The best place to get started is the [Server Testing
         Instructions](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Instructions-<%= ig_metadata.ig_version %>),
-        which provides a step-by-step guide for running the tests against a client and provides
-        an example client implemented in Postman.  Visit the [Server Testing
+        which provides a step-by-step guide for running the tests. Visit the [Server Testing
         Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)
         documentation for information about technical implementation and known limitations of these tests.
 
@@ -34,6 +33,7 @@ module DaVinciPASTestKit
             - Approval of a prior authorization request
             - Denial of a prior authorization request
             - Pending of a prior authorization request and a subsequent final decision
+            - Claim updates (except in v2.0.1)
             - Inability to process a prior authorization request
         - The ability of the server to handle the full scope of data required by PAS, including
             - Ability to process prior auth requests and inquiries with all PAS profiles and all must support elements on those profiles
@@ -48,7 +48,7 @@ module DaVinciPASTestKit
         required features and functionality are present. HL7® FHIR® resources are 
         validated with the Java validator using `tx.fhir.org` as the terminology server.
       
-      %)
+      )
 
       links [
         {

--- a/lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/server/generated/v2.0.1/server_suite.rb
@@ -24,8 +24,7 @@ module DaVinciPASTestKit
 
         The best place to get started is the [Server Testing
         Instructions](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Instructions-v2.0.1),
-        which provides a step-by-step guide for running the tests against a client and provides
-        an example client implemented in Postman.  Visit the [Server Testing
+        which provides a step-by-step guide for running the tests. Visit the [Server Testing
         Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)
         documentation for information about technical implementation and known limitations of these tests.
 
@@ -36,6 +35,7 @@ module DaVinciPASTestKit
             - Approval of a prior authorization request
             - Denial of a prior authorization request
             - Pending of a prior authorization request and a subsequent final decision
+            - Claim updates (except in v2.0.1)
             - Inability to process a prior authorization request
         - The ability of the server to handle the full scope of data required by PAS, including
             - Ability to process prior auth requests and inquiries with all PAS profiles and all must support elements on those profiles
@@ -50,7 +50,7 @@ module DaVinciPASTestKit
         required features and functionality are present. HL7® FHIR® resources are 
         validated with the Java validator using `tx.fhir.org` as the terminology server.
       
-      %)
+      )
 
       links [
         {

--- a/lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb
+++ b/lib/davinci_pas_test_kit/server/generated/v2.2.1/server_suite.rb
@@ -25,8 +25,7 @@ module DaVinciPASTestKit
 
         The best place to get started is the [Server Testing
         Instructions](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Instructions-v2.2.1),
-        which provides a step-by-step guide for running the tests against a client and provides
-        an example client implemented in Postman.  Visit the [Server Testing
+        which provides a step-by-step guide for running the tests. Visit the [Server Testing
         Details](https://github.com/inferno-framework/davinci-pas-test-kit/wiki/Server-Details)
         documentation for information about technical implementation and known limitations of these tests.
 
@@ -37,6 +36,7 @@ module DaVinciPASTestKit
             - Approval of a prior authorization request
             - Denial of a prior authorization request
             - Pending of a prior authorization request and a subsequent final decision
+            - Claim updates (except in v2.0.1)
             - Inability to process a prior authorization request
         - The ability of the server to handle the full scope of data required by PAS, including
             - Ability to process prior auth requests and inquiries with all PAS profiles and all must support elements on those profiles
@@ -51,7 +51,7 @@ module DaVinciPASTestKit
         required features and functionality are present. HL7® FHIR® resources are 
         validated with the Java validator using `tx.fhir.org` as the terminology server.
       
-      %)
+      )
 
       links [
         {


### PR DESCRIPTION
# Summary

This adds instructions for running the v2.2.1 server suite. I also reviewed the existing page for running server suite and client suite against each other and found no issues.

# Testing Guidance

Try following the quick start instructions using the client suite as the SUT